### PR TITLE
Java SDK returns null when JSON Parse problems occur

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtil.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtil.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.hyperwallet.clientsdk.HyperwalletException;
 import com.hyperwallet.clientsdk.model.HyperwalletBaseMonitor;
 import org.apache.commons.lang3.StringUtils;
 
@@ -28,7 +29,7 @@ public class HyperwalletJsonUtil {
         try {
             return HyperwalletJsonUtil.parser.readValue(content, valueType);
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new HyperwalletException(e);
         }
     }
 
@@ -39,7 +40,7 @@ public class HyperwalletJsonUtil {
         try {
             return HyperwalletJsonUtil.parser.readValue(content, valueType);
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new HyperwalletException(e);
         }
     }
 

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtil.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtil.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.hyperwallet.clientsdk.model.HyperwalletBaseMonitor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 
@@ -21,24 +22,24 @@ public class HyperwalletJsonUtil {
     }
 
     public static <T> T fromJson(final String content, final Class<T> valueType) {
-        if (content == null) {
+        if (StringUtils.isBlank(content)) {
             return null;
         }
         try {
             return HyperwalletJsonUtil.parser.readValue(content, valueType);
         } catch (IOException e) {
-            return null;
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 
     public static <T> T fromJson(final String content, final TypeReference<T> valueType) {
-        if (content == null) {
+        if (StringUtils.isBlank(content)) {
             return null;
         }
         try {
             return HyperwalletJsonUtil.parser.readValue(content, valueType);
         } catch (IOException e) {
-            return null;
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
@@ -799,7 +799,7 @@ public class HyperwalletApiClientTest {
         }
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test(expectedExceptions = HyperwalletException.class)
     public void testInvalidJsonResponse() throws Exception {
         TestBody requestBody = new TestBody();
         requestBody.test1 = "value1";

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtilTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtilTest.java
@@ -23,6 +23,7 @@ public class HyperwalletJsonUtilTest {
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class TestBody {
         public String test;
+        public Double amount;
     }
 
     @JsonFilter(HyperwalletJsonConfiguration.INCLUSION_FILTER)
@@ -69,6 +70,17 @@ public class HyperwalletJsonUtilTest {
         assertThat(body, is(nullValue()));
     }
 
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testFromJson_byClassReference_Invalid_JSON_Content() {
+        HyperwalletJsonUtil.fromJson("{\"amount\": \"1,023.37\" }", TestBody.class);
+    }
+
+    @Test
+    public void testFromJson_byClassReference_Valid_JSON_Content() {
+        TestBody body = HyperwalletJsonUtil.fromJson("{\"amount\": \"1023.37\" }", TestBody.class);
+        assertThat(body.amount, is(1023.37));
+    }
+
     @Test
     public void testFromJson_byClassReference_emptyContent() {
         TestBody body = HyperwalletJsonUtil.fromJson("", TestBody.class);
@@ -92,6 +104,11 @@ public class HyperwalletJsonUtilTest {
     public void testFromJson_byTypeReference_emptyContent() {
         TestBody body = HyperwalletJsonUtil.fromJson("", new TypeReference<TestBody>() {});
         assertThat(body, is(nullValue()));
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testFromJson_byTypeReference_Invalid_JSON_Content() {
+        HyperwalletJsonUtil.fromJson("{\"amount\" : }", new TypeReference<TestBody>() {});
     }
 
     @Test

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtilTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletJsonUtilTest.java
@@ -2,6 +2,7 @@ package com.hyperwallet.clientsdk.util;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.hyperwallet.clientsdk.HyperwalletException;
 import com.hyperwallet.clientsdk.model.HyperwalletBaseMonitor;
 import org.testng.annotations.Test;
 
@@ -70,7 +71,7 @@ public class HyperwalletJsonUtilTest {
         assertThat(body, is(nullValue()));
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test(expectedExceptions = HyperwalletException.class)
     public void testFromJson_byClassReference_Invalid_JSON_Content() {
         HyperwalletJsonUtil.fromJson("{\"amount\": \"1,023.37\" }", TestBody.class);
     }
@@ -106,7 +107,7 @@ public class HyperwalletJsonUtilTest {
         assertThat(body, is(nullValue()));
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test(expectedExceptions = HyperwalletException.class)
     public void testFromJson_byTypeReference_Invalid_JSON_Content() {
         HyperwalletJsonUtil.fromJson("{\"amount\" : }", new TypeReference<TestBody>() {});
     }


### PR DESCRIPTION
When there are non-parseable JSON response in HTTP body JDK API client returns null which is undesirable since the user of the SDK will not have a clue on what is going on its request.
