### PR TITLE
Fix payment notes field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - Added list program account receipt endpoint
 - Added list user receipt endpoint
 - Added list prepaid card receipt endpoint
+- Fixed the payment representation (renamed description to notes)
 
 0.1.0 (2016-06-30)
 ------------------

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Installation
 <dependency>
     <groupId>com.hyperwallet</groupId>
     <artifactId>sdk</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
 **Gradle**
 ```
-compile 'com.hyperwallet:sdk:0.1.0'
+compile 'com.hyperwallet:sdk:0.2.0'
 ```
 
 Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hyperwallet</groupId>
     <artifactId>sdk</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>hyperwallet-java-sdk</name>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng.version>6.11</testng.version>
+        <testng.version>6.10</testng.version>
         <mockito.version>2.2.28</mockito.version>
         <protea.http.version>[0.2,)</protea.http.version>
         <jackson.jaxrs.json.provider.version>2.5.3</jackson.jaxrs.json.provider.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng.version>6.8</testng.version>
-        <mockito.version>1.10.19</mockito.version>
+        <testng.version>6.11</testng.version>
+        <mockito.version>2.2.28</mockito.version>
         <protea.http.version>[0.2,)</protea.http.version>
         <jackson.jaxrs.json.provider.version>2.5.3</jackson.jaxrs.json.provider.version>
-        <org.apache.commons.commons-lang3.version>3.4</org.apache.commons.commons-lang3.version>
+        <org.apache.commons.commons-lang3.version>3.5</org.apache.commons.commons-lang3.version>
     </properties>
 
     <dependencies>
@@ -169,7 +169,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -197,7 +197,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>4.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
@@ -18,7 +18,7 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
     private Date createdOn;
     private Double amount;
     private String currency;
-    private String description;
+    private String notes;
     private String memo;
     private String purpose;
     private Date releaseOn;
@@ -132,24 +132,24 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
         return this;
     }
 
-    public String getDescription() {
-        return description;
+    public String getNotes() {
+        return notes;
     }
 
-    public void setDescription(String description) {
-        addField("description", description);
-        this.description = description;
+    public void setNotes(String notes) {
+        addField("notes", notes);
+        this.notes = notes;
     }
 
-    public HyperwalletPayment description(String description) {
-        addField("description", description);
-        this.description = description;
+    public HyperwalletPayment notes(String notes) {
+        addField("notes", notes);
+        this.notes = notes;
         return this;
     }
 
-    public HyperwalletPayment clearDescription() {
-        clearField("description");
-        this.description = null;
+    public HyperwalletPayment clearNotes() {
+        clearField("notes");
+        this.notes = null;
         return this;
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
@@ -15,7 +15,7 @@ public class HyperwalletPaymentTest extends BaseModelTest<HyperwalletPayment> {
                 .currency("test-currency")
 
                 .memo("test-memo")
-                .description("test-description")
+                .notes("test-note")
 
                 .purpose("test-purpose")
                 .releaseOn(new Date())


### PR DESCRIPTION
The Payment model contains a field called `description` instead of the proper one called `notes`