### PR TITLE
Add read and connect timeouts to HyperwalletApiClient

### DIFF
--- a/src/main/java/cc/protea/util/http/TimedRequest.java
+++ b/src/main/java/cc/protea/util/http/TimedRequest.java
@@ -1,0 +1,22 @@
+package cc.protea.util.http;
+
+
+public class TimedRequest extends Request {
+
+    /**
+     *
+     * @param url The URL to connect to
+     * @param connectTimeout connect timeout in ms
+     * @param readTimeout read timeout in ms
+     */
+    public TimedRequest(final String url, final int connectTimeout, final int readTimeout) {
+        super(url);
+        if (connectTimeout > 0) {
+            connection.setConnectTimeout(connectTimeout);
+        }
+        if (readTimeout > 0) {
+            connection.setReadTimeout(readTimeout);
+        }
+    }
+
+}

--- a/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
+++ b/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
@@ -27,15 +27,30 @@ public class Hyperwallet {
     /**
      * Create Hyperwallet SDK instance
      *
+     * @param username       API key assigned
+     * @param password       API Password assigned
+     * @param programToken   API program token
+     * @param server         API server url
+     * @param connectTimeout connect timeout in ms
+     * @param readTimeout    read timeout in ms
+     */
+    public Hyperwallet(final String username, final String password, final String programToken, final String server,
+                       final int connectTimeout, final int readTimeout) {
+        apiClient = new HyperwalletApiClient(username, password, VERSION, connectTimeout, readTimeout);
+        this.programToken = programToken;
+        this.url = StringUtils.isEmpty(server) ? "https://api.sandbox.hyperwallet.com/rest/v3" : server + "/rest/v3";
+    }
+
+    /**
+     * Create Hyperwallet SDK instance
+     *
      * @param username     API key assigned
      * @param password     API Password assigned
      * @param programToken API program token
-     * @param server          API serer url
+     * @param server       API server url
      */
     public Hyperwallet(final String username, final String password, final String programToken, final String server) {
-        apiClient = new HyperwalletApiClient(username, password, VERSION);
-        this.programToken = programToken;
-        this.url = StringUtils.isEmpty(server) ? "https://api.sandbox.hyperwallet.com/rest/v3" : server + "/rest/v3";
+        this(username, password, programToken, server, -1, -1);
     }
 
     /**
@@ -52,11 +67,37 @@ public class Hyperwallet {
     /**
      * Create Hyperwallet SDK instance
      *
+     * @param username       API key assigned
+     * @param password       API password
+     * @param programToken   API program token assigned
+     * @param connectTimeout connect timeout in ms
+     * @param readTimeout    read timeout in ms
+     */
+    public Hyperwallet(final String username, final String password, final String programToken,
+                       final int connectTimeout, final int readTimeout) {
+        this(username, password, programToken, null, connectTimeout, readTimeout);
+    }
+
+    /**
+     * Create Hyperwallet SDK instance
+     *
      * @param username API key assigned
      * @param password API password
      */
     public Hyperwallet(final String username, final String password) {
         this(username, password, null);
+    }
+
+    /**
+     * Create Hyperwallet SDK instance
+     *
+     * @param username       API key assigned
+     * @param password       API password
+     * @param connectTimeout connect timeout in ms
+     * @param readTimeout    read timeout in ms
+     */
+    public Hyperwallet(final String username, final String password, final int connectTimeout, final int readTimeout) {
+        this(username, password, null, connectTimeout, readTimeout);
     }
 
     //--------------------------------------

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
@@ -2,6 +2,7 @@ package com.hyperwallet.clientsdk.util;
 
 import cc.protea.util.http.Request;
 import cc.protea.util.http.Response;
+import cc.protea.util.http.TimedRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.hyperwallet.clientsdk.HyperwalletException;
 import com.hyperwallet.clientsdk.model.HyperwalletErrorList;
@@ -15,11 +16,16 @@ public class HyperwalletApiClient {
     private final String username;
     private final String password;
     private final String version;
+    private final int connectTimeout;
+    private final int readTimeout;
 
-    public HyperwalletApiClient(final String username, final String password, final String version) {
+    public HyperwalletApiClient(final String username, final String password, final String version,
+                                final int connectTimeout, final int readTimeout) {
         this.username = username;
         this.password = password;
         this.version = version;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
 
         // TLS fix
         if (System.getProperty("java.version").startsWith("1.7.")) {
@@ -126,12 +132,12 @@ public class HyperwalletApiClient {
 
     private Request getService(final String url, boolean isHttpGet) {
         if (isHttpGet) {
-            return new Request(url)
+            return new TimedRequest(url, connectTimeout, readTimeout)
                     .addHeader("Authorization", getAuthorizationHeader())
                     .addHeader("Accept", "application/json")
                     .addHeader("User-Agent", "Hyperwallet Java SDK v" + version);
         } else {
-            return new Request(url)
+            return new TimedRequest(url, connectTimeout, readTimeout)
                     .addHeader("Authorization", getAuthorizationHeader())
                     .addHeader("Accept", "application/json")
                     .addHeader("Content-Type", "application/json")

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
@@ -74,7 +74,7 @@ public class HyperwalletApiClientTest {
         }
 
         baseUrl = "http://localhost:" + mockServer.getPort();
-        hyperwalletApiClient = new HyperwalletApiClient("test-username", "test-password", "1.0");
+        hyperwalletApiClient = new HyperwalletApiClient("test-username", "test-password", "1.0", -1, -1);
     }
 
     @Test


### PR DESCRIPTION
Add matching constructors for every existing Hyperwallet class constructor, to accept connect and read timeouts. This is passed along to HyperwalletApiClient which now uses TimedRequest instead of just Request. (Note this is in the cc.protea package - which is an externally-imported library; TimedRequest is in the corresponding package inside java-sdk).  

We have been unable enforce read and connect timeouts using the Hyperwallet SDK, causing us to wrap the calls to Hyperwallet in a thread that has an execution timeout. However, this is less than ideal: there is little insight as to what state the connection was in when the thread is terminated. 