### PR TITLE
bugfix/set character set on output stream writer to UTF 8

### DIFF
--- a/src/main/java/cc/protea/util/http/Request.java
+++ b/src/main/java/cc/protea/util/http/Request.java
@@ -1,0 +1,305 @@
+package cc.protea.util.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+
+ Modified with modifications copyright Richard Stanford
+
+ -- Original portions by Joe Ernst --
+
+ * Copyright 2012 Joe J. Ernst
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class represents an HTTP Request message.
+ */
+public class Request extends Message<Request> {
+
+    HttpURLConnection connection;
+    OutputStreamWriter writer;
+
+    URL url;
+    Map<String, String> query = new HashMap<String, String>();
+
+    /**
+     * The Constructor takes the url as a String.
+     *
+     * @param url
+     *            The url parameter does not need the query string parameters if they are going to be supplied via calls to
+     *            {@link #addQueryParameter(String, String)}. You can, however, supply the query parameters in the URL if you wish.
+     */
+    public Request(final String url) {
+        try {
+            this.url = new URL(url);
+            this.connection = (HttpURLConnection) this.url.openConnection();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    /**
+     * Adds a Query Parameter to a list. The list is converted to a String and appended to the URL when the Request is submitted.
+     *
+     * @param name
+     *            The Query Parameter's name
+     * @param value
+     *            The Query Parameter's value
+     * @return this Request, to support chained method calls
+     */
+    public Request addQueryParameter(final String name, final String value) {
+        this.query.put(name, value);
+        return this;
+    }
+
+    /**
+     * Removes the specified Query Parameter.
+     *
+     * @param name
+     *            The name of the Query Parameter to remove
+     * @return this Request, to support chained method calls
+     */
+    public Request removeQueryParameter(final String name) {
+        this.query.remove(name);
+        return this;
+    }
+
+    /**
+     * Issues a GET to the server.
+     *
+     * @return The {@link Response} from the server
+     * @throws IOException
+     */
+    public Response getResource() throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod("GET");
+
+        return readResponse();
+    }
+
+    /**
+     * Issues a PUT to the server.
+     *
+     * @return The {@link Response} from the server
+     * @throws IOException
+     */
+    public Response putResource() throws IOException {
+        return writeResource("PUT", this.body);
+    }
+
+    public Response headResource() throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod("HEAD");
+
+        return readResponse();
+    }
+
+    public Response optionsResource() throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod("OPTIONS");
+
+        return readResponse();
+    }
+
+    public Response traceResource() throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod("TRACE");
+
+        return readResponse();
+    }
+
+    /**
+     * Issues a POST to the server.
+     *
+     * @return The {@link Response} from the server
+     * @throws IOException
+     */
+    public Response postResource() throws IOException {
+        return writeResource("POST", this.body);
+    }
+
+    /**
+     * Issues a DELETE to the server.
+     *
+     * @return The {@link Response} from the server
+     * @throws IOException
+     */
+    public Response deleteResource() throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod("DELETE");
+
+        return readResponse();
+    }
+
+    /**
+     * A private method that handles issuing POST and PUT requests
+     *
+     * @param method
+     *            POST or PUT
+     * @param body
+     *            The body of the Message
+     * @return the {@link Response} from the server
+     * @throws IOException
+     */
+    private Response writeResource(final String method, final String body) throws IOException {
+        buildQueryString();
+        buildHeaders();
+
+        connection.setDoOutput(true);
+        connection.setRequestMethod(method);
+
+        writer = new OutputStreamWriter(connection.getOutputStream(), "UTF-8");
+        writer.write(body);
+        writer.close();
+
+        return readResponse();
+    }
+
+    /**
+     * A private method that handles reading the Responses from the server.
+     *
+     * @return a {@link Response} from the server.
+     * @throws IOException
+     */
+    private Response readResponse() throws IOException {
+        Response response = new Response();
+        response.setResponseCode(connection.getResponseCode());
+        response.setResponseMessage(connection.getResponseMessage());
+        response.setHeaders(connection.getHeaderFields());
+        try {
+            response.setBody(getStringFromStream(connection.getInputStream()));
+        } catch (IOException e) {
+            response.setBody(getStringFromStream(connection.getErrorStream()));
+        }
+        return response;
+    }
+
+    private String getStringFromStream(final InputStream is) {
+        if (is == null) {
+            return null;
+        }
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(is));
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append("\n");
+            }
+            return builder.toString();
+        } catch (IOException e) {
+            return null;
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    // no-op
+                }
+            }
+        }
+    }
+
+    /**
+     * A private method that loops through the query parameter Map, building a String to be appended to the URL.
+     *
+     * @throws MalformedURLException
+     */
+    private void buildQueryString() throws MalformedURLException {
+        StringBuilder builder = new StringBuilder();
+
+        // Put the query parameters on the URL before issuing the request
+        if (!query.isEmpty()) {
+            for (Map.Entry<String, String> param : query.entrySet()) {
+                builder.append(param.getKey());
+                builder.append("=");
+                builder.append(param.getValue());
+                builder.append("&");
+            }
+            builder.deleteCharAt(builder.lastIndexOf("&")); // Remove the trailing ampersand
+        }
+
+        if (builder.length() > 0) {
+            // If there was any query string at all, begin it with the question mark
+            builder.insert(0, "?");
+        }
+
+        url = new URL(url.toString() + builder.toString());
+    }
+
+    /**
+     * A private method that loops through the headers Map, putting them on the Request or Response object.
+     */
+    private void buildHeaders() {
+        if (!headers.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                List<String> values = entry.getValue();
+
+                for (String value : values) {
+                    connection.addRequestProperty(entry.getKey(), value);
+                }
+            }
+        }
+    }
+
+    public Request setBodyUrlEncoded(final Map<String, String> map) {
+
+        if (map == null) {
+            this.body = null;
+            return this;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            sb.append(first ? "" : "&").append(encode(entry.getKey())).append("=").append(encode(entry.getValue()));
+            first = false;
+        }
+
+        setBody(sb.toString());
+        addHeader("Content-type", "application/x-www-form-urlencoded");
+        addHeader("Content-length", "" + (body.length()));
+
+        return this;
+    }
+
+}

--- a/src/main/java/cc/protea/util/http/Utf8Request.java
+++ b/src/main/java/cc/protea/util/http/Utf8Request.java
@@ -36,7 +36,7 @@ import java.util.Map;
 /**
  * This class represents an HTTP Request message.
  */
-public class Request extends Message<Request> {
+public class Utf8Request extends Message<Utf8Request> {
 
     HttpURLConnection connection;
     OutputStreamWriter writer;
@@ -51,7 +51,7 @@ public class Request extends Message<Request> {
      *            The url parameter does not need the query string parameters if they are going to be supplied via calls to
      *            {@link #addQueryParameter(String, String)}. You can, however, supply the query parameters in the URL if you wish.
      */
-    public Request(final String url) {
+    public Utf8Request(final String url) {
         try {
             this.url = new URL(url);
             this.connection = (HttpURLConnection) this.url.openConnection();
@@ -70,7 +70,7 @@ public class Request extends Message<Request> {
      *            The Query Parameter's value
      * @return this Request, to support chained method calls
      */
-    public Request addQueryParameter(final String name, final String value) {
+    public Utf8Request addQueryParameter(final String name, final String value) {
         this.query.put(name, value);
         return this;
     }
@@ -82,7 +82,7 @@ public class Request extends Message<Request> {
      *            The name of the Query Parameter to remove
      * @return this Request, to support chained method calls
      */
-    public Request removeQueryParameter(final String name) {
+    public Utf8Request removeQueryParameter(final String name) {
         this.query.remove(name);
         return this;
     }
@@ -280,7 +280,7 @@ public class Request extends Message<Request> {
         }
     }
 
-    public Request setBodyUrlEncoded(final Map<String, String> map) {
+    public Utf8Request setBodyUrlEncoded(final Map<String, String> map) {
 
         if (map == null) {
             this.body = null;

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
@@ -1,6 +1,6 @@
 package com.hyperwallet.clientsdk.util;
 
-import cc.protea.util.http.Request;
+import cc.protea.util.http.Utf8Request;
 import cc.protea.util.http.Response;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.hyperwallet.clientsdk.HyperwalletException;
@@ -73,7 +73,7 @@ public class HyperwalletApiClient {
         Response response = null;
         try {
             String body = convert(bodyObject);
-            Request request = getService(url, false).setBody(body);
+            Utf8Request request = getService(url, false).setBody(body);
 
             if (header != null) {
                 for (String key : header.keySet()) {
@@ -124,14 +124,14 @@ public class HyperwalletApiClient {
         return "Basic " + base64;
     }
 
-    private Request getService(final String url, boolean isHttpGet) {
+    private Utf8Request getService(final String url, boolean isHttpGet) {
         if (isHttpGet) {
-            return new Request(url)
+            return new Utf8Request(url)
                     .addHeader("Authorization", getAuthorizationHeader())
                     .addHeader("Accept", "application/json")
                     .addHeader("User-Agent", "Hyperwallet Java SDK v" + version);
         } else {
-            return new Request(url)
+            return new Utf8Request(url)
                     .addHeader("Authorization", getAuthorizationHeader())
                     .addHeader("Accept", "application/json")
                     .addHeader("Content-Type", "application/json")


### PR DESCRIPTION
The existing HTTP client from cc.protea uses an `OutputStreamWriter` with the one-argument constructer, leading it to accept the system default character set. 

This presents issues as Hyperwallet accepts a certain character set, but does not know which characters the client's host OS supports by default.

The change sets the character set to UTF-8, which is in accordance with Hyperwallet specifications. 

n.b. I highly recommend that Hyperwallet migrates away from using the `cc.protea` HTTP library. The library is useful in that it's syntactic sugar for `HttpURLConnection`, but past that it's detrimental in terms of debuggability. I opened [another pull request](https://github.com/hyperwallet/java-sdk/pull/14) that also overrides a cc.protea class - and most of the functionality provided by the `cc.protea` library would be replicated by allowing the `HyperwalletApiClient` class to accept an HttpClient parameter. 