### PR TITLE
Added status param to HyperwalletPayment pojo

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
+++ b/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
@@ -1418,6 +1418,7 @@ public class Hyperwallet {
         }
         payment = copy(payment);
         payment.setCreatedOn(null);
+        payment.setStatus(null);
         return apiClient.post(url + "/payments", payment, HyperwalletPayment.class);
     }
 

--- a/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
+++ b/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
@@ -1418,7 +1418,6 @@ public class Hyperwallet {
         }
         payment = copy(payment);
         payment.setCreatedOn(null);
-        payment.setStatus(null);
         return apiClient.post(url + "/payments", payment, HyperwalletPayment.class);
     }
 

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
@@ -13,7 +13,12 @@ import java.util.Date;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class HyperwalletPayment extends HyperwalletBaseMonitor {
 
+    public static enum Status {CREATED, SCHEDULED, PENDING_ACCOUNT_ACTIVATION, PENDING_TAX_VERIFICATION,
+        PENDING_TRANSFER_METHOD_ACTION, PENDING_TRANSACTION_VERIFICATION, IN_PROGRESS, COMPLETED,
+        CANCELLED, FAILED, RECALLED, RETURNED, EXPIRED}
+
     private String token;
+    private Status status;
 
     private Date createdOn;
     private Double amount;
@@ -45,6 +50,27 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
     public HyperwalletPayment clearToken() {
         clearField("token");
         this.token = null;
+        return this;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        addField("status", status);
+        this.status = status;
+    }
+
+    public HyperwalletPayment status(Status status) {
+        addField("status", status);
+        this.status = status;
+        return this;
+    }
+
+    public HyperwalletPayment clearStatus() {
+        clearField("status");
+        status = null;
         return this;
     }
 

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
@@ -13,12 +13,8 @@ import java.util.Date;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class HyperwalletPayment extends HyperwalletBaseMonitor {
 
-    public static enum Status {CREATED, SCHEDULED, PENDING_ACCOUNT_ACTIVATION, PENDING_TAX_VERIFICATION,
-        PENDING_TRANSFER_METHOD_ACTION, PENDING_TRANSACTION_VERIFICATION, IN_PROGRESS, COMPLETED,
-        CANCELLED, FAILED, RECALLED, RETURNED, EXPIRED}
-
     private String token;
-    private Status status;
+    private String status;
 
     private Date createdOn;
     private Double amount;
@@ -53,16 +49,16 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
         return this;
     }
 
-    public Status getStatus() {
+    public String getStatus() {
         return status;
     }
 
-    public void setStatus(Status status) {
+    public void setStatus(String status) {
         addField("status", status);
         this.status = status;
     }
 
-    public HyperwalletPayment status(Status status) {
+    public HyperwalletPayment status(String status) {
         addField("status", status);
         this.status = status;
         return this;

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
@@ -3931,7 +3931,7 @@ public class HyperwalletTest {
     }
 
     @Test
-    public void     testCreateBankAccountStatusTransition_noBankAccountToken() {
+    public void testCreateBankAccountStatusTransition_noBankAccountToken() {
         Hyperwallet client = new Hyperwallet("test-username", "test-password");
         try {
             client.createBankAccountStatusTransition("test-user-token", null, new HyperwalletStatusTransition());

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
@@ -3931,7 +3931,7 @@ public class HyperwalletTest {
     }
 
     @Test
-    public void testCreateBankAccountStatusTransition_noBankAccountToken() {
+    public void     testCreateBankAccountStatusTransition_noBankAccountToken() {
         Hyperwallet client = new Hyperwallet("test-username", "test-password");
         try {
             client.createBankAccountStatusTransition("test-user-token", null, new HyperwalletStatusTransition());
@@ -4524,7 +4524,7 @@ public class HyperwalletTest {
         HyperwalletPayment payment = new HyperwalletPayment();
         payment.setCreatedOn(new Date());
         payment.setCurrency("test-currency");
-        payment.setStatus(HyperwalletPayment.Status.COMPLETED);
+        payment.setStatus("COMPLETED");
 
         HyperwalletPayment paymentResponse = new HyperwalletPayment();
 
@@ -4553,7 +4553,7 @@ public class HyperwalletTest {
         payment.setCreatedOn(new Date());
         payment.setCurrency("test-currency");
         payment.setProgramToken("test-program-token2");
-        payment.setStatus(HyperwalletPayment.Status.COMPLETED);
+        payment.setStatus("COMPLETED");
 
         HyperwalletPayment paymentResponse = new HyperwalletPayment();
 

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
@@ -4513,6 +4513,7 @@ public class HyperwalletTest {
 
         HyperwalletPayment apiClientPayment = argument.getValue();
         assertThat(apiClientPayment, is(notNullValue()));
+        assertThat(apiClientPayment.getStatus(), is(nullValue()));
         assertThat(apiClientPayment.getCurrency(), is(equalTo("test-currency")));
         assertThat(apiClientPayment.getCreatedOn(), is(nullValue()));
         assertThat(apiClientPayment.getProgramToken(), is(nullValue()));
@@ -4523,6 +4524,7 @@ public class HyperwalletTest {
         HyperwalletPayment payment = new HyperwalletPayment();
         payment.setCreatedOn(new Date());
         payment.setCurrency("test-currency");
+        payment.setStatus(HyperwalletPayment.Status.COMPLETED);
 
         HyperwalletPayment paymentResponse = new HyperwalletPayment();
 
@@ -4539,6 +4541,7 @@ public class HyperwalletTest {
 
         HyperwalletPayment apiClientPayment = argument.getValue();
         assertThat(apiClientPayment, is(notNullValue()));
+        assertThat(apiClientPayment.getStatus(), is(notNullValue()));
         assertThat(apiClientPayment.getCurrency(), is(equalTo("test-currency")));
         assertThat(apiClientPayment.getCreatedOn(), is(nullValue()));
         assertThat(apiClientPayment.getProgramToken(), is(equalTo("test-program-token")));
@@ -4550,6 +4553,7 @@ public class HyperwalletTest {
         payment.setCreatedOn(new Date());
         payment.setCurrency("test-currency");
         payment.setProgramToken("test-program-token2");
+        payment.setStatus(HyperwalletPayment.Status.COMPLETED);
 
         HyperwalletPayment paymentResponse = new HyperwalletPayment();
 
@@ -4566,6 +4570,7 @@ public class HyperwalletTest {
 
         HyperwalletPayment apiClientPayment = argument.getValue();
         assertThat(apiClientPayment, is(notNullValue()));
+        assertThat(apiClientPayment.getStatus(), is(notNullValue()));
         assertThat(apiClientPayment.getCurrency(), is(equalTo("test-currency")));
         assertThat(apiClientPayment.getCreatedOn(), is(nullValue()));
         assertThat(apiClientPayment.getProgramToken(), is(equalTo("test-program-token2")));

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
@@ -9,7 +9,7 @@ public class HyperwalletPaymentTest extends BaseModelTest<HyperwalletPayment> {
     protected HyperwalletPayment createBaseModel() {
         HyperwalletPayment payment = new HyperwalletPayment();
         payment
-                .status(HyperwalletPayment.Status.COMPLETED)
+                .status("COMPLETED")
                 .token("test-token")
                 .createdOn(new Date())
                 .amount(15.99)

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
@@ -9,6 +9,7 @@ public class HyperwalletPaymentTest extends BaseModelTest<HyperwalletPayment> {
     protected HyperwalletPayment createBaseModel() {
         HyperwalletPayment payment = new HyperwalletPayment();
         payment
+                .status(HyperwalletPayment.Status.COMPLETED)
                 .token("test-token")
                 .createdOn(new Date())
                 .amount(15.99)


### PR DESCRIPTION
Added status to HyperwalletPayment pojo class.

**Description:**
Current HyperwallletPayment pojo doesn't have the status parameter. Without the status clients cannot view the status of the payment.

**Changes:**
Status is created as enum. The values of the enum are referred from the Hyperwallet external [documentation](https://docs.hyperwallet.com/content/api/v3/resources/payments/retrieve#attributes).

- [x] Tested this feature in local.
- [x] Added relevant changes to the existing test case.

**Test Result:**
<img width="1650" alt="Screen Shot 2020-05-28 at 3 08 10 PM" src="https://user-images.githubusercontent.com/6824987/83125394-1a7c3200-a0f5-11ea-9dfe-d7b0b34acc3d.png">


Created an issue for the same. For more details please refer [issue 50](https://github.com/hyperwallet/java-sdk/issues/50).