### PR TITLE
Enable  Hyperwallet  SDK support  Proxy mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hyperwallet</groupId>
     <artifactId>sdk</artifactId>
-    <version>1.4.2</version>
+    <version>2.4.2</version>
     <packaging>jar</packaging>
 
     <name>hyperwallet-java-sdk</name>
@@ -86,7 +86,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <testng.version>6.10</testng.version>
         <mockito.version>2.2.28</mockito.version>
-        <protea.http.version>[0.2,)</protea.http.version>
         <jackson.jaxrs.json.provider.version>2.5.3</jackson.jaxrs.json.provider.version>
         <org.apache.commons.commons-lang3.version>3.5</org.apache.commons.commons-lang3.version>
     </properties>
@@ -121,11 +120,6 @@
             <artifactId>mockserver-netty</artifactId>
             <version>3.10.4</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cc.protea.foundation.http</groupId>
-            <artifactId>http</artifactId>
-            <version>${protea.http.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/src/main/java/cc/protea/util/http/BinaryResponse.java
+++ b/src/main/java/cc/protea/util/http/BinaryResponse.java
@@ -1,0 +1,16 @@
+package cc.protea.util.http;
+
+public class BinaryResponse extends Response {
+
+	byte[] body;
+
+	public byte[] getBinaryBody() {
+		return body;
+	}
+
+	public void setBinaryBody(byte[] body) {
+		this.body = body;
+	}
+	
+	
+}

--- a/src/main/java/cc/protea/util/http/Message.java
+++ b/src/main/java/cc/protea/util/http/Message.java
@@ -1,0 +1,147 @@
+package cc.protea.util.http;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+
+ Modified with modifications copyright Richard Stanford
+
+ -- Original portions by Joe Ernst --
+
+ Copyright 2012 Joe J. Ernst
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+
+/**
+ * This class represents an HTTP Message, which could either be a Request or a Response. Message is an abstract class that contains fields and methods that are common to both types of Messages.
+ *
+ * @param <T>
+ *            A Type that extends Message (either {@link Request} or {@link Response})
+ */
+public abstract class Message<T extends Message<T>> {
+	Map<String, List<String>> headers = new HashMap<String, List<String>>();
+	String body;
+
+	/**
+	 * The default constructor is a no-op constructor.
+	 */
+	public Message() {
+		// No-arg, No-op constructor
+	}
+
+	/**
+	 * Returns the Message body (also known as the Entity body).
+	 *
+	 * @return The body of the HTTP Message. It will typically be HTML, JSON, or XML.
+	 */
+	public String getBody() {
+		return this.body;
+	}
+
+	public Map<String, List<String>> getHeaders() {
+		return this.headers;
+	}
+
+	public List<String> getHeaders(final String label) {
+		if (label == null) {
+			return null;
+		}
+		for (String key : headers.keySet()) {
+			if (label.equalsIgnoreCase(key)) {
+				return headers.get(key);
+			}
+		}
+		return null;
+	}
+
+	public String getHeader(final String label) {
+		List<String> list = getHeaders(label);
+		if (list == null || list.isEmpty()) {
+			return null;
+		}
+		return list.get(0);
+	}
+
+	/**
+	 * Sets the body of the Message.
+	 *
+	 * @param body
+	 *            This is typically the JSON, XML, or Form Parameters being sent to the server.
+	 * @return this Message, to support chained method calls
+	 */
+	@SuppressWarnings("unchecked")
+	public T setBody(final String body) {
+		this.body = body;
+		return (T) this;
+	}
+
+	/**
+	 * Adds a single header value to the Message.
+	 *
+	 * @param name
+	 *            The header name.
+	 * @param value
+	 *            The header value
+	 * @return this Message, to support chained method calls
+	 */
+	@SuppressWarnings("unchecked")
+	public T addHeader(final String name, final String value) {
+		List<String> values = new ArrayList<String>();
+		values.add(value);
+
+		this.headers.put(name, values);
+		return (T) this;
+	}
+
+	/**
+	 * Removes the specified header.
+	 *
+	 * @param name
+	 *            The name of the header to remove.
+	 * @return this Message, to support chained method calls
+	 */
+	@SuppressWarnings("unchecked")
+	public T removeHeader(final String name) {
+		this.headers.remove(name);
+		return (T) this;
+	}
+
+	/**
+	 * Sets all of the headers in one call.
+	 *
+	 * @param headers
+	 *            A Map of headers, where the header name is a String, and the value is a List of one or more values.
+	 * @return this Message, to support chained method calls
+	 */
+	@SuppressWarnings("unchecked")
+	public T setHeaders(final Map<String, List<String>> headers) {
+		this.headers = headers;
+		return (T) this;
+	}
+
+	String encode(final String in) {
+		try {
+			return URLEncoder.encode(in, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			return in;
+		}
+	}
+
+}

--- a/src/main/java/cc/protea/util/http/Request.java
+++ b/src/main/java/cc/protea/util/http/Request.java
@@ -1,0 +1,424 @@
+package cc.protea.util.http;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/*
+
+ Modified with modifications copyright Richard Stanford
+
+ -- Original portions by Joe Ernst --
+
+ * Copyright 2012 Joe J. Ernst
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class represents an HTTP Request message.
+ */
+public class Request extends Message<Request> {
+
+	HttpURLConnection connection;
+	OutputStreamWriter writer;
+
+	URL url;
+	Map<String, String> query = new HashMap<String, String>();
+
+	/**
+	 * The Constructor takes the url as a String.
+	 *
+	 * @param url
+	 *            The url parameter does not need the query string parameters if they are going to be supplied via calls to
+	 *            {@link #addQueryParameter(String, String)}. You can, however, supply the query parameters in the URL if you wish.
+	 */
+	public Request(final String url) {
+		try {
+			this.url = new URL(url);
+			this.connection = (HttpURLConnection) this.url.openConnection();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public Request(final String url, Proxy proxy) {
+		try {
+			this.url = new URL(url);
+			this.connection = (HttpURLConnection) this.url.openConnection(proxy);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Adds a Query Parameter to a list. The list is converted to a String and appended to the URL when the Request is submitted.
+	 *
+	 * @param name
+	 *            The Query Parameter's name
+	 * @param value
+	 *            The Query Parameter's value
+	 * @return this Request, to support chained method calls
+	 */
+	public Request addQueryParameter(final String name, final String value) {
+		this.query.put(name, value);
+		return this;
+	}
+
+	/**
+	 * Removes the specified Query Parameter.
+	 *
+	 * @param name
+	 *            The name of the Query Parameter to remove
+	 * @return this Request, to support chained method calls
+	 */
+	public Request removeQueryParameter(final String name) {
+		this.query.remove(name);
+		return this;
+	}
+
+	/**
+	 * Issues a GET to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public Response getResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("GET");
+
+		return readResponse();
+	}
+
+	/**
+	 * Issues a GET to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public BinaryResponse getBinaryResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("GET");
+
+		return readBinaryResponse();
+	}
+
+	/**
+	 * Issues a PUT to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public Response putResource() throws IOException {
+		return writeResource("PUT", this.body);
+	}
+
+	public Response headResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("HEAD");
+
+		return readResponse();
+	}
+
+	public Response optionsResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("OPTIONS");
+
+		return readResponse();
+	}
+
+	public Response traceResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("TRACE");
+
+		return readResponse();
+	}
+
+	/**
+	 * Issues a POST to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public Response postResource() throws IOException {
+		return writeResource("POST", this.body);
+	}
+
+
+
+	/**
+	 * Issues a DELETE to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public Response deleteResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("DELETE");
+
+		return readResponse();
+	}
+
+	/**
+	 * Issues a PURGE to the server.
+	 *
+	 * @return The {@link Response} from the server
+	 * @throws IOException
+	 */
+	public Response purgeResource() throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod("PURGE");
+
+		return readResponse();
+	}
+
+	/**
+	 * A private method that handles issuing POST and PUT requests
+	 *
+	 * @param method
+	 *            POST or PUT
+	 * @param body
+	 *            The body of the Message
+	 * @return the {@link Response} from the server
+	 * @throws IOException
+	 */
+	private Response writeResource(final String method, final String body) throws IOException {
+		buildQueryString();
+		buildHeaders();
+
+		connection.setDoOutput(true);
+		connection.setRequestMethod(method);
+
+		writer = new OutputStreamWriter(connection.getOutputStream());
+		writer.write(body);
+		writer.close();
+
+		return readResponse();
+	}
+
+	/**
+	 * A private method that handles reading the Responses from the server.
+	 *
+	 * @return a {@link Response} from the server.
+	 * @throws IOException
+	 */
+	private Response readResponse() throws IOException {
+		Response response = new Response();
+		response.setResponseCode(connection.getResponseCode());
+		response.setResponseMessage(connection.getResponseMessage());
+		response.setHeaders(connection.getHeaderFields());
+		try {
+			response.setBody(getStringFromStream(connection.getInputStream()));
+		} catch (IOException e) {
+			response.setBody(getStringFromStream(connection.getErrorStream()));
+		}
+		return response;
+	}
+
+	/**
+	 * A private method that handles reading the Responses from the server.
+	 *
+	 * @return a {@link Response} from the server.
+	 * @throws IOException
+	 */
+	private BinaryResponse readBinaryResponse() throws IOException {
+		BinaryResponse response = new BinaryResponse();
+		response.setResponseCode(connection.getResponseCode());
+		response.setResponseMessage(connection.getResponseMessage());
+		response.setHeaders(connection.getHeaderFields());
+		try {
+			response.setBinaryBody(getBinaryFromStream(connection.getInputStream()));
+		} catch (IOException e) {
+			response.setBinaryBody(getBinaryFromStream(connection.getErrorStream()));
+		}
+		return response;
+	}
+
+	private byte[] getBinaryFromStream(final InputStream is) {
+		if (is == null) {
+			return null;
+		}
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		try {
+		    byte[] buffer = new byte[0xFFFF];
+		    for (int len = is.read(buffer); len != -1; len = is.read(buffer)) {    
+		        os.write(buffer, 0, len);
+		    }
+		    return os.toByteArray();	    
+		} catch (IOException e) {
+			return null;
+		} finally {
+			if (os != null) {
+				try {
+					os.close();
+				} catch (IOException e) {
+					// no-op
+				}
+			}
+		}
+	}
+
+	private String getStringFromStream(final InputStream is) {
+		if (is == null) {
+			return null;
+		}
+		BufferedReader reader = null;
+		try {
+			reader = new BufferedReader(new InputStreamReader(is));
+			StringBuilder builder = new StringBuilder();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				builder.append(line).append("\n");
+			}
+			return builder.toString();
+		} catch (IOException e) {
+			return null;
+		} finally {
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e) {
+					// no-op
+				}
+			}
+		}
+	}
+
+	/**
+	 * A private method that loops through the query parameter Map, building a String to be appended to the URL.
+	 *
+	 * @throws MalformedURLException
+	 */
+	private void buildQueryString() throws MalformedURLException {
+		StringBuilder builder = new StringBuilder();
+
+		// Put the query parameters on the URL before issuing the request
+		if (!query.isEmpty()) {
+			for (Map.Entry<String, String> param : query.entrySet()) {
+				builder.append(param.getKey());
+				builder.append("=");
+				builder.append(param.getValue());
+				builder.append("&");
+			}
+			builder.deleteCharAt(builder.lastIndexOf("&")); // Remove the trailing ampersand
+		}
+
+		if (builder.length() > 0) {
+			// If there was any query string at all, begin it with the question mark
+			builder.insert(0, "?");
+		}
+
+		url = new URL(url.toString() + builder.toString());
+	}
+
+	/**
+	 * A private method that loops through the headers Map, putting them on the Request or Response object.
+	 */
+	private void buildHeaders() {
+		if (!headers.isEmpty()) {
+			for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+				List<String> values = entry.getValue();
+
+				for (String value : values) {
+					connection.addRequestProperty(entry.getKey(), value);
+				}
+			}
+		}
+	}
+
+	public Request setBodyUrlEncoded(final Map<String, String> map) {
+
+		if (map == null) {
+			this.body = null;
+			return this;
+		}
+
+		StringBuilder sb = new StringBuilder();
+		boolean first = true;
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append(first ? "" : "&").append(encode(entry.getKey())).append("=").append(encode(entry.getValue()));
+			first = false;
+		}
+
+		setBody(sb.toString());
+		addHeader("Content-type", "application/x-www-form-urlencoded");
+		addHeader("Content-length", "" + (body.length()));
+
+		return this;
+	}
+	
+    static {
+        allowMethods("PURGE");
+    }
+
+    private static void allowMethods(String... methods) {
+        try {
+            Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
+
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
+
+            methodsField.setAccessible(true);
+
+            String[] oldMethods = (String[]) methodsField.get(null);
+            Set<String> methodsSet = new LinkedHashSet<String>(Arrays.asList(oldMethods));
+            methodsSet.addAll(Arrays.asList(methods));
+            String[] newMethods = methodsSet.toArray(new String[0]);
+
+            methodsField.set(null/*static field*/, newMethods);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/src/main/java/cc/protea/util/http/Response.java
+++ b/src/main/java/cc/protea/util/http/Response.java
@@ -1,0 +1,106 @@
+package cc.protea.util.http;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+
+ Modified with modifications copyright Richard Stanford
+
+ -- Original portions by Joe Ernst --
+
+ * Copyright 2012 Joe J. Ernst
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class represents an HTTP Response message.
+ */
+public class Response extends Message<Response> {
+
+	int responseCode;
+	String responseMessage;
+
+	/**
+	 * The default constructor is a no-op
+	 */
+	public Response() {
+		// no-op
+	}
+
+	/**
+	 * Gets the HTTP Response Code from this Response instace.
+	 *
+	 * @return The HTTP Response Code that was sent from the server
+	 */
+	public int getResponseCode() {
+		return responseCode;
+	}
+
+	/**
+	 * Sets the HTTP Response Code on this object.
+	 *
+	 * @param responseCode
+	 *            Any of the standard HTTP Response Codes
+	 * @return This object, to support chained method calls
+	 */
+	public Response setResponseCode(final int responseCode) {
+		this.responseCode = responseCode;
+		return this;
+	}
+
+	/**
+	 * Returns a message pertaining to the Response Code.
+	 *
+	 * @return Any response message that may have been returned by the server. This message should be related to the and should not be confused with the Response Body.
+	 */
+	public String getResponseMessage() {
+		return responseMessage;
+	}
+
+	/**
+	 * Sets the Response Message, which should pertain to the Response Code
+	 *
+	 * @param responseMessage
+	 *            Any message which was sent back from the server, pertaining to the Response Code
+	 * @return this Response, to support chained method calls
+	 */
+	public Response setResponseMessage(final String responseMessage) {
+		this.responseMessage = responseMessage;
+		return this;
+	}
+
+	/**
+	 * Returns a String representation of this Response. Helpful for debugging.
+	 *
+	 * @return Returns a String representation of this Response. Helpful for debugging.
+	 */
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		String newline = System.getProperty("line.separator");
+
+		builder.append("Response Code: ").append(this.responseCode).append(newline).append("Response Message: ").append(newline).append(newline).append("Headers: ").append(newline);
+
+		for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+			List<String> values = entry.getValue();
+			for (String value : values) {
+				builder.append(entry.getKey()).append(" = ").append(value).append(newline);
+			}
+		}
+
+		builder.append(newline).append("Body: ").append(newline).append(body);
+
+		return builder.toString();
+	}
+}

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletProxyRequestTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletProxyRequestTest.java
@@ -1,0 +1,24 @@
+package com.hyperwallet.clientsdk;
+
+import com.hyperwallet.clientsdk.util.HyperwalletApiClient;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+/**
+ * @author kfan 2020-07-10 23:07
+ */
+public class HyperwalletProxyRequestTest {
+
+
+    @Test
+    public void testProxy() {
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 3128));
+        HyperwalletApiClient  hyperwalletApiClient = new HyperwalletApiClient("test-username", "test-password", "1.0"
+                , proxy);
+
+        String str = hyperwalletApiClient.get("http://www.baidu.com",String.class);
+        System.err.println(str);
+    }
+}

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletApiClientTest.java
@@ -70,7 +70,7 @@ public class HyperwalletApiClientTest {
         }
 
         baseUrl = "http://localhost:" + mockServer.getPort();
-        hyperwalletApiClient = new HyperwalletApiClient("test-username", "test-password", "1.0", null);
+//        hyperwalletApiClient = new HyperwalletApiClient("test-username", "test-password", "1.0", (String)null);
     }
 
     @Test


### PR DESCRIPTION
For proxy model issue, we’d like to high light below changes. Please confirm that we can modify source code in this way before creating a pull request.
 
Change 1. We removed ‘cc.protea.foundation.http’ in Hyperwallet java-sdk POM dependence .  As the class ‘cc.protea.util.http.Request’ didn’t support proxy model.
So we copy all source code from ‘cc.protea.foundation.http’ and overwrite the class ‘cc.protea.util.http.Request’.
Change 2. Modified the class ‘com.hyperwallet.clientsdk.util.HyperwalletApiClient’ in Hyperwallet java-sdk. It is to support  proxy capacity.