### PR TITLE
upgrade dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -84,11 +84,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng.version>6.10</testng.version>
-        <mockito.version>2.2.28</mockito.version>
+        <testng.version>7.3.0</testng.version>
+        <mockito.version>3.5.7</mockito.version>
         <protea.http.version>[0.2,)</protea.http.version>
-        <jackson.jaxrs.json.provider.version>2.5.3</jackson.jaxrs.json.provider.version>
-        <org.apache.commons.commons-lang3.version>3.5</org.apache.commons.commons-lang3.version>
+        <jackson.jaxrs.json.provider.version>2.11.2</jackson.jaxrs.json.provider.version>
+        <org.apache.commons.commons-lang3.version>3.11</org.apache.commons.commons-lang3.version>
     </properties>
 
     <dependencies>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.10.4</version>
+            <version>5.11.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -140,13 +140,13 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>7.9</version>
+            <version>8.20</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <scope>test</scope>
-            <version>20180130</version>
+            <version>20200518</version>
         </dependency>
     </dependencies>
 
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -165,7 +165,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -190,7 +190,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -245,7 +245,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <MOCK_SERVER_PORT>${mockServerPort}</MOCK_SERVER_PORT>
@@ -255,7 +255,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.2</version>
                 <executions>
                     <execution>
                         <configuration>


### PR DESCRIPTION
Upgraded the dependencies to the latest versions in Sonatype. Please approve.

**Jar file | Initial Version | Updated version**
commons-lang3(org.apache.commons.commons-lang3.version) | 3.5 | 3.11 
jackson-jaxrs-json-provider | 2.5.3 | 2.11.2
json | 20180130 | 20200518 
maven-assembly-plugin | 3.0.0 | 3.3.0 
maven-compiler-plugin | 2.3.2 | 3.8.1 
maven-failsafe-plugin | 2.20.1 | 2.22.2
maven-javadoc-plugin | 2.10.4 | 3.2.0 
maven-source-plugin | 3.0.1 | 3.2.1 
maven-surefire-plugin | 2.19.1 | 2.22.2
mockito-core | 2.2.28 | 3.5.7
mockserver-netty | 3.10.4 | 5.11.1
nexus-staging-maven-plugin | 1.6.7 | 1.6.8
nimbus-jose-jwt | 7.9 | 8.20
TestNg | 6.1 | 7.3.0

