### PR TITLE
V3-java-DTRUNEONE-1501-Missing-data types DATE and PHONE

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodConfiguration.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodConfiguration.java
@@ -38,7 +38,7 @@ public class HyperwalletTransferMethodConfiguration {
 
         public enum Category {ACCOUNT, INTERMEDIARY_ACCOUNT, PROFILE, ADDRESS}
 
-        public enum DataType {TEXT, SELECTION, BOOLEAN, NUMBER}
+        public enum DataType {TEXT, SELECTION, BOOLEAN, NUMBER, DATE, PHONE}
 
         private String name;
         private String label;

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
@@ -4,6 +4,8 @@ import com.hyperwallet.clientsdk.model.*;
 import com.hyperwallet.clientsdk.model.HyperwalletPrepaidCard.Brand;
 import com.hyperwallet.clientsdk.model.HyperwalletTransfer.ForeignExchange;
 import com.hyperwallet.clientsdk.model.HyperwalletTransferMethod.CardType;
+import com.hyperwallet.clientsdk.model.HyperwalletTransferMethod.Type;
+import com.hyperwallet.clientsdk.model.HyperwalletTransferMethodConfiguration.Field.DataType;
 import com.hyperwallet.clientsdk.model.HyperwalletUser.*;
 import com.hyperwallet.clientsdk.model.HyperwalletVerificationDocumentReason.RejectReason;
 import com.hyperwallet.clientsdk.util.Multipart;
@@ -880,6 +882,32 @@ public class HyperwalletIT {
         assertThat(returnValue.getData().get(0).getForeignExchanges().get(0).getDestinationCurrency(), is(equalTo("USD")));
         assertThat(returnValue.getData().get(0).getForeignExchanges().get(0).getRate(), is(equalTo(0.79)));
     }
+
+    //
+    //TransferMethodConfiguration
+    //
+
+    @Test
+    public void testGetTransferMethodConfiguration() throws Exception {
+        String functionality = "getTransferMethodConfiguration";
+        initMockServer(functionality);
+
+        HyperwalletTransferMethodConfiguration returnValue;
+        try {
+            returnValue = client.getTransferMethodConfiguration("usr-b86ab524-2787-46e2-b536-5a70e37349f7","US","USD", Type.BANK_ACCOUNT, ProfileType.INDIVIDUAL);
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+
+        assertThat(returnValue.getCountries().get(0), is(equalTo("US")));
+        assertThat(returnValue.getCurrencies().get(0), is(equalTo("USD")));
+        assertThat(returnValue.getFields().get(0).getDataType(), is(equalTo(DataType.NUMBER)));
+    }
+
+    //
+    //TransferStatusTransition
+    //
 
     @Test
     public void testCreateTransferStatusTransition() throws Exception {

--- a/src/test/resources/integration/getTransferMethodConfiguration-request.txt
+++ b/src/test/resources/integration/getTransferMethodConfiguration-request.txt
@@ -1,0 +1,3 @@
+curl -X "GET" "https://api.sandbox.hyperwallet.com/rest/v3/transfer-method-configurations" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Accept: application/json"

--- a/src/test/resources/integration/getTransferMethodConfiguration-response.json
+++ b/src/test/resources/integration/getTransferMethodConfiguration-response.json
@@ -1,0 +1,48 @@
+{
+  "countries": [
+    "US"
+  ],
+  "currencies": [
+    "USD"
+  ],
+  "type": "BANK_ACCOUNT",
+  "profileType": "INDIVIDUAL",
+  "fields": [
+    {
+      "name": "branchId",
+      "label": "Routing Number",
+      "category": "ACCOUNT",
+      "dataType": "NUMBER",
+      "isRequired": true,
+      "regularExpression": "[0-9]{9}",
+      "minLength": 9,
+      "maxLength": 9
+    },
+    {
+      "name": "bankAccountId",
+      "label": "Account Number",
+      "category": "ACCOUNT",
+      "dataType": "NUMBER",
+      "isRequired": true,
+      "regularExpression": "^(?![0-]+$)[0-9-]{4,20}$",
+      "minLength": 4,
+      "maxLength": 20
+    },
+    {
+      "name": "firstName",
+      "label": "First Name",
+      "category": "PROFILE",
+      "dataType": "TEXT",
+      "isRequired": true,
+      "regularExpression": "[a-zA-Z]"
+    }
+  ],
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v3/transfer-method-configurations/usr-b86ab524-2787-46e2-b536-5a70e37349f7"
+    }
+  ]
+}


### PR DESCRIPTION
Users received following exception as their SDK couldn't deserialize the values of data fields 'DATE' and 'PHONE'. They were using version 1.7.2. The issue is occurring until now in SDK-V3. The issue has been rectified by adding enumerations for 'Phone' and 'Date' data fields in the class **HyperwalletTransferMethodConfiguration**.

Exception occurecom.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type 'com.hyperwallet.clientsdk.model.HyperwalletTransferMethodConfiguration$Field$DataType` from String "PHONE": not one of the values accepted for Enum class: [BOOLEAN, NUMBER, SELECTION, TEXT]