### PR TITLE
DTRUNEONE-4371 Adding Support for EC Encryption Keys

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
@@ -1,9 +1,34 @@
 package com.hyperwallet.clientsdk.util;
 
 import com.hyperwallet.clientsdk.HyperwalletException;
-import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.*;
-import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEDecrypter;
+import com.nimbusds.jose.JWEEncrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.ECDHDecrypter;
+import com.nimbusds.jose.crypto.ECDHEncrypter;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.RSAKey;
+
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +37,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.ParseException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
 
 public class HyperwalletEncryption {
 

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
@@ -1,24 +1,9 @@
 package com.hyperwallet.clientsdk.util;
 
 import com.hyperwallet.clientsdk.HyperwalletException;
-import com.nimbusds.jose.Algorithm;
-import com.nimbusds.jose.EncryptionMethod;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSObject;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.RSADecrypter;
-import com.nimbusds.jose.crypto.RSAEncrypter;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.crypto.RSASSAVerifier;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.*;
+import com.nimbusds.jose.jwk.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,11 +11,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
+import java.util.*;
 
 public class HyperwalletEncryption {
 
@@ -41,30 +23,61 @@ public class HyperwalletEncryption {
     private static final JWEAlgorithm ENCRYPTION_ALGORITHM = JWEAlgorithm.RSA_OAEP_256;
     private static final JWSAlgorithm SIGN_ALGORITHM = JWSAlgorithm.RS256;
     private static final EncryptionMethod ENCRYPTION_METHOD = EncryptionMethod.A256CBC_HS512;
+    private static final String INVALID_KEY_TYPE_STRING = "'kty' not supported = %s";
 
-    private JWEAlgorithm encryptionAlgorithm;
-    private JWSAlgorithm signAlgorithm;
-    private EncryptionMethod encryptionMethod;
-    private String clientPrivateKeySetLocation;
-    private String hyperwalletKeySetLocation;
-    private Integer jwsExpirationMinutes;
+    private static final List<JWEAlgorithm> SUPPORTED_JWE_ALGORITHMS = Arrays.asList(JWEAlgorithm.RSA_OAEP_256,
+            JWEAlgorithm.ECDH_ES,
+            JWEAlgorithm.ECDH_ES_A128KW,
+            JWEAlgorithm.ECDH_ES_A192KW,
+            JWEAlgorithm.ECDH_ES_A256KW);
+    private static final List<JWSAlgorithm> SUPPORTED_JWS_ALGORITHMS = Arrays.asList(JWSAlgorithm.RS256,
+            JWSAlgorithm.RS384,
+            JWSAlgorithm.RS512,
+            JWSAlgorithm.PS256,
+            JWSAlgorithm.PS384,
+            JWSAlgorithm.PS512,
+            JWSAlgorithm.ES256,
+            JWSAlgorithm.ES384,
+            JWSAlgorithm.ES512);
+    private static final List<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS = Arrays.asList(EncryptionMethod.A128CBC_HS256,
+            EncryptionMethod.A192CBC_HS384,
+            EncryptionMethod.A256CBC_HS512,
+            EncryptionMethod.A128GCM,
+            EncryptionMethod.A256GCM);
+
+    private final JWEAlgorithm encryptionAlgorithm;
+    private final JWSAlgorithm signAlgorithm;
+    private final EncryptionMethod encryptionMethod;
+    private final String clientPrivateKeySetLocation;
+    private final String hyperwalletKeySetLocation;
+    private final Integer jwsExpirationMinutes;
 
     public HyperwalletEncryption(JWEAlgorithm encryptionAlgorithm, JWSAlgorithm signAlgorithm, EncryptionMethod encryptionMethod,
-                                 String clientPrivateKeySetLocation, String hyperwalletKeySetLocation, Integer jwsExpirationMinutes) {
+            String clientPrivateKeySetLocation, String hyperwalletKeySetLocation, Integer jwsExpirationMinutes) {
         this.encryptionAlgorithm = encryptionAlgorithm == null ? ENCRYPTION_ALGORITHM : encryptionAlgorithm;
         this.signAlgorithm = signAlgorithm == null ? SIGN_ALGORITHM : signAlgorithm;
         this.encryptionMethod = encryptionMethod == null ? ENCRYPTION_METHOD : encryptionMethod;
         this.clientPrivateKeySetLocation = clientPrivateKeySetLocation;
         this.hyperwalletKeySetLocation = hyperwalletKeySetLocation;
         this.jwsExpirationMinutes = jwsExpirationMinutes == null ? EXPIRATION_MINUTES : jwsExpirationMinutes;
+
+        if (!SUPPORTED_JWS_ALGORITHMS.contains(this.signAlgorithm)) {
+            throw new IllegalArgumentException("Unsupported signing algorithm " + this.signAlgorithm);
+        }
+        if (!SUPPORTED_JWE_ALGORITHMS.contains(this.encryptionAlgorithm)) {
+            throw new IllegalArgumentException("Unsupported encryption algorithm " + this.encryptionAlgorithm);
+        }
+        if (!SUPPORTED_ENCRYPTION_METHODS.contains(this.encryptionMethod)) {
+            throw new IllegalArgumentException("Unsupported encryption method " + this.encryptionMethod);
+        }
     }
 
     public String encrypt(String body) throws JOSEException, IOException, ParseException {
 
         JWK clientPrivateKey = getKeyByAlgorithm(loadKeySet(clientPrivateKeySetLocation), signAlgorithm);
         JWK hyperwalletPublicKey = getKeyByAlgorithm(loadKeySet(hyperwalletKeySetLocation), encryptionAlgorithm);
-
-        JWSSigner signer = new RSASSASigner((RSAKey)clientPrivateKey);
+        JWSSigner signer = getJWSSigner(clientPrivateKey);
+        JWEEncrypter jwsEncrypter = getJWEEncrypter(hyperwalletPublicKey);
 
         JWSObject jwsObject = new JWSObject(
                 new JWSHeader.Builder(signAlgorithm)
@@ -80,7 +93,7 @@ public class HyperwalletEncryption {
                         .keyID(hyperwalletPublicKey.getKeyID()).build(),
                 new Payload(jwsObject));
 
-        jweObject.encrypt(new RSAEncrypter((RSAKey)hyperwalletPublicKey));
+        jweObject.encrypt(jwsEncrypter);
 
         return jweObject.serialize();
     }
@@ -88,16 +101,16 @@ public class HyperwalletEncryption {
     public String decrypt(String body) throws ParseException, IOException, JOSEException {
 
         JWK privateKeyToDecrypt = getKeyByAlgorithm(loadKeySet(clientPrivateKeySetLocation), encryptionAlgorithm);
-        RSAPublicKey publicKeyToSign = ((RSAKey)getKeyByAlgorithm(loadKeySet(hyperwalletKeySetLocation), signAlgorithm))
-                .toRSAPublicKey();
+        JWK publicKeyToSign = getKeyByAlgorithm(loadKeySet(hyperwalletKeySetLocation), signAlgorithm);
+        JWEDecrypter jweDecrypter = getJWEDecrypter(privateKeyToDecrypt);
+        JWSVerifier verifier = getJWSVerifier(publicKeyToSign);
 
         JWEObject jweObject = JWEObject.parse(body);
-        jweObject.decrypt(new RSADecrypter((RSAKey)privateKeyToDecrypt));
+        jweObject.decrypt(jweDecrypter);
         JWSObject jwsObject = jweObject.getPayload().toJWSObject();
         verifySignatureExpirationDate(jwsObject.getHeader().getCustomParam(EXPIRATION));
-        boolean verifyStatus = jwsObject.verify(new RSASSAVerifier(publicKeyToSign,
-                new HashSet<>(Collections.singletonList(EXPIRATION))));
-        if(!verifyStatus) {
+        boolean verifyStatus = jwsObject.verify(verifier);
+        if (!verifyStatus) {
             throw new HyperwalletException("JWS signature is incorrect");
         }
         return jwsObject.getPayload().toString();
@@ -110,8 +123,8 @@ public class HyperwalletEncryption {
         if (!(signatureExpirationDate instanceof Long)) {
             throw new HyperwalletException("exp JWS header must be of type Long");
         }
-        long expirationTimeSeconds = (long)signatureExpirationDate;
-        if (new Date().getTime()/MILLISECONDS_IN_SECOND > expirationTimeSeconds) {
+        long expirationTimeSeconds = (long) signatureExpirationDate;
+        if (new Date().getTime() / MILLISECONDS_IN_SECOND > expirationTimeSeconds) {
             throw new HyperwalletException("Response message signature(JWS) has expired");
         }
     }
@@ -152,12 +165,12 @@ public class HyperwalletEncryption {
     }
 
     private long getJWSExpirationMillis() {
-        return new Date(new Date().getTime() + MILLISECONDS_IN_ONE_MINUTE * jwsExpirationMinutes).getTime()/MILLISECONDS_IN_SECOND;
+        return new Date(new Date().getTime() + MILLISECONDS_IN_ONE_MINUTE * jwsExpirationMinutes).getTime() / MILLISECONDS_IN_SECOND;
     }
 
     private <T extends Algorithm> JWK getKeyByAlgorithm(JWKSet keySet, T algorithm) {
-        for(JWK key : keySet.getKeys()) {
-            if(key.getAlgorithm().equals(algorithm)) {
+        for (JWK key : keySet.getKeys()) {
+            if (key.getAlgorithm().equals(algorithm)) {
                 return key;
             }
         }
@@ -170,7 +183,68 @@ public class HyperwalletEncryption {
         }
     }
 
+    private JWSSigner getJWSSigner(JWK jwk) {
+        try {
+            KeyType kty = jwk.getKeyType();
+            if (kty.equals(KeyType.RSA)) {
+                return new RSASSASigner((RSAKey) jwk);
+            } else if (kty.equals(KeyType.EC)) {
+                return new ECDSASigner((ECKey) jwk);
+            } else {
+                throw new IllegalArgumentException(String.format(INVALID_KEY_TYPE_STRING, kty));
+            }
+        } catch (JOSEException e) {
+            throw new HyperwalletException("Unable to create signer");
+        }
+    }
+
+    private JWEEncrypter getJWEEncrypter(JWK jwk) {
+        try {
+            KeyType kty = jwk.getKeyType();
+            if (kty.equals(KeyType.RSA)) {
+                return new RSAEncrypter((RSAKey) jwk);
+            } else if (kty.equals(KeyType.EC)) {
+                return new ECDHEncrypter((ECKey) jwk);
+            } else {
+                throw new IllegalArgumentException(String.format(INVALID_KEY_TYPE_STRING, kty));
+            }
+        } catch (JOSEException e) {
+            throw new HyperwalletException("Unable to create encrypter");
+        }
+    }
+
+    private JWSVerifier getJWSVerifier(JWK jwk) {
+        try {
+            KeyType kty = jwk.getKeyType();
+            if (kty.equals(KeyType.RSA)) {
+                return new RSASSAVerifier(((RSAKey) jwk).toRSAPublicKey(), new HashSet<>(Collections.singletonList(EXPIRATION)));
+            } else if (kty.equals(KeyType.EC)) {
+                return new ECDSAVerifier(((ECKey) jwk).toECPublicKey(), new HashSet<>(Collections.singletonList(EXPIRATION)));
+            } else {
+                throw new IllegalArgumentException(String.format(INVALID_KEY_TYPE_STRING, kty));
+            }
+        } catch (JOSEException e) {
+            throw new HyperwalletException("Unable to create verifier");
+        }
+    }
+
+    private JWEDecrypter getJWEDecrypter(JWK jwk) {
+        try {
+            KeyType kty = jwk.getKeyType();
+            if (kty.equals(KeyType.RSA)) {
+                return new RSADecrypter((RSAKey) jwk);
+            } else if (kty.equals(KeyType.EC)) {
+                return new ECDHDecrypter((ECKey) jwk);
+            } else {
+                throw new IllegalArgumentException(String.format(INVALID_KEY_TYPE_STRING, kty));
+            }
+        } catch (JOSEException e) {
+            throw new HyperwalletException("Unable to create decrypter");
+        }
+    }
+
     public static class HyperwalletEncryptionBuilder {
+
         private JWEAlgorithm encryptionAlgorithm;
         private JWSAlgorithm signAlgorithm;
         private EncryptionMethod encryptionMethod;

--- a/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletEncryptionTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/util/HyperwalletEncryptionTest.java
@@ -283,27 +283,6 @@ public class HyperwalletEncryptionTest {
         }
     }
 
-    @Test
-    public void shouldThrowExceptionWhenEncryptionAlgorithmIsNotFoundInKeySet1()
-            throws URISyntaxException, IOException, ParseException, JOSEException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String hyperwalletKeysPath = new File(classLoader.getResource("encryption/public-jwkset").toURI()).getAbsolutePath();
-        String clientPrivateKeysPath = new File(classLoader.getResource("encryption/private-jwkset").toURI()).getAbsolutePath();
-        String testPayload = IOUtils.toString(classLoader.getResourceAsStream("encryption/test-payload.json"));
-
-        HyperwalletEncryption hyperwalletEncryption = new HyperwalletEncryption.HyperwalletEncryptionBuilder()
-                .clientPrivateKeySetLocation(clientPrivateKeysPath).hyperwalletKeySetLocation(hyperwalletKeysPath)
-                .encryptionAlgorithm(JWEAlgorithm.ECDH_ES).build();
-
-        try {
-            hyperwalletEncryption.encrypt(testPayload);
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is(containsString("Algorithm = ECDH-ES is not found in client or Hyperwallet key set")));
-        }
-    }
-
-
     private Method findGetter(String fieldName) throws Exception {
         String getterName = "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
         return HyperwalletEncryption.class.getMethod(getterName);

--- a/src/test/resources/encryption/private-jwkset-ec
+++ b/src/test/resources/encryption/private-jwkset-ec
@@ -1,0 +1,24 @@
+{
+  "keys": [
+    {
+        "kty": "EC",
+        "d": "CQ7fBVWs-xn97g7NEAWBbvMHNj1G5_PnKZ2EizNtKFM",
+        "use": "sig",
+        "crv": "P-256",
+        "kid": "2022_sig_rsa_ES256_2048",
+        "x": "CV1UHUfozG_2SC0RHiUNji6H_gnVF983yHpqA5rLJmE",
+        "y": "-hnV_jQwmwi5Gwcj9eCUNe9r3NlLaZaHwbmBngn3S7s",
+        "alg": "ES256"
+    },
+    {
+        "kty": "EC",
+        "d": "rYUtmp4JFWk07jz5wMIAXET9YpDYxggiqFbwfgluem8",
+        "use": "enc",
+        "crv": "P-256",
+        "kid": "2022_enc_ec_P-256_ECDH-ES",
+        "x": "LbR5tW4Sn4b60jHfzXHiJF8j-C1dBB4PQueJo2gkWM0",
+        "y": "1w_8_VdKEpmNnzQl2uqPUS2JlrJnCa-4_KJuvyBm31k",
+        "alg": "ECDH-ES"
+    }
+  ]
+}

--- a/src/test/resources/encryption/private-jwkset-unsupported-key
+++ b/src/test/resources/encryption/private-jwkset-unsupported-key
@@ -1,0 +1,23 @@
+{
+  "keys": [
+    {
+        "kty": "EC",
+        "d": "CQ7fBVWs-xn97g7NEAWBbvMHNj1G5_PnKZ2EizNtKFM",
+        "use": "sig",
+        "crv": "P-256",
+        "kid": "2022_sig_rsa_ES256_2048",
+        "x": "CV1UHUfozG_2SC0RHiUNji6H_gnVF983yHpqA5rLJmE",
+        "y": "-hnV_jQwmwi5Gwcj9eCUNe9r3NlLaZaHwbmBngn3S7s",
+        "alg": "ES256"
+    },
+    {
+        "kty": "OKP",
+        "d": "eZCs2KCulPRogH9vlsdHvn5kBi_Wgekrh9Adn0S8D70",
+        "use": "enc",
+        "crv": "Ed25519",
+        "kid": "2022_enc_okp_ED25519_ECDH-ES",
+        "x": "TFzuxL3nQ_xlUK98Qz1n5Rx3hxCKZz-AqFfPjRvKveQ",
+        "alg": "ECDH-ES"
+    }
+  ]
+}

--- a/src/test/resources/encryption/public-jwkset-ec
+++ b/src/test/resources/encryption/public-jwkset-ec
@@ -1,0 +1,22 @@
+{
+  "keys": [
+    {
+        "kty": "EC",
+        "use": "sig",
+        "crv": "P-256",
+        "kid": "2022_sig_rsa_ES256_2048",
+        "x": "CV1UHUfozG_2SC0RHiUNji6H_gnVF983yHpqA5rLJmE",
+        "y": "-hnV_jQwmwi5Gwcj9eCUNe9r3NlLaZaHwbmBngn3S7s",
+        "alg": "ES256"
+    },
+    {
+        "kty": "EC",
+        "use": "enc",
+        "crv": "P-256",
+        "kid": "2022_enc_ec_P-256_ECDH-ES",
+        "x": "LbR5tW4Sn4b60jHfzXHiJF8j-C1dBB4PQueJo2gkWM0",
+        "y": "1w_8_VdKEpmNnzQl2uqPUS2JlrJnCa-4_KJuvyBm31k",
+        "alg": "ECDH-ES"
+    }
+  ]
+}

--- a/src/test/resources/encryption/public-jwkset-unsupported-key
+++ b/src/test/resources/encryption/public-jwkset-unsupported-key
@@ -1,0 +1,21 @@
+{
+  "keys": [
+    {
+        "kty": "EC",
+        "use": "sig",
+        "crv": "P-256",
+        "kid": "2022_sig_rsa_ES256_2048",
+        "x": "CV1UHUfozG_2SC0RHiUNji6H_gnVF983yHpqA5rLJmE",
+        "y": "-hnV_jQwmwi5Gwcj9eCUNe9r3NlLaZaHwbmBngn3S7s",
+        "alg": "ES256"
+    },
+    {
+        "kty": "OKP",
+        "use": "enc",
+        "crv": "Ed25519",
+        "kid": "2022_enc_okp_ED25519_ECDH-ES",
+        "x": "TFzuxL3nQ_xlUK98Qz1n5Rx3hxCKZz-AqFfPjRvKveQ",
+        "alg": "ECDH-ES"
+    }
+  ]
+}


### PR DESCRIPTION
- Adding validation for our supported JWE/JWS algorithms (https://docs.hyperwallet.com/content/api/v3/overview/payload-encryption)
- Adding support for EC type keys (encrypting and decrypting)

```
[INFO] Tests run: 1805, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.6 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1805, Failures: 0, Errors: 0, Skipped: 0
```

**Testing Local**
RSA Keys (JWS Algorithm - RS256, JWEAlgorithm - RSA_OAEP_256)
- Create User ✅ 
- Retrieve User ✅ 
- Update User ✅ 

EC Keys (JWS Algorithm - ES256, JWEAlgorithm - ECDH_ES)
- Create User ✅ 
- Retrieve User ✅
- Update User ✅