### PR TITLE
DTRUNEONE-4575 Update error handling V3

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/HyperwalletException.java
+++ b/src/main/java/com/hyperwallet/clientsdk/HyperwalletException.java
@@ -39,6 +39,14 @@ public class HyperwalletException extends RuntimeException {
         relatedResources = error.getRelatedResources();
     }
 
+    public HyperwalletException(final Response response, final int code, final String message, final Exception e) {
+        super(e);
+
+        this.response = response;
+        errorCode = Integer.toString(code);
+        errorMessage = message;
+    }
+
     public HyperwalletException(final String errorMessage) {
         super(errorMessage);
 

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletApiClient.java
@@ -225,7 +225,7 @@ public class HyperwalletApiClient {
     /**
      * Method to handle error responses based on the content type header.  Although the HyperWallet encryption object is set, it is still possible to
      * receive an error response with content type=application/json.  Please see the following
-     * <a href="https://docs.hyperwallet.com/content/api/v4/overview/payload-encryption">documentation</a>.
+     * <a href="https://docs.hyperwallet.com/content/api/v3/overview/payload-encryption">documentation</a>.
      *
      * @param response The response received from the server
      * @return The decrypted error response

--- a/src/test/resources/encryption/server-private-jwkset
+++ b/src/test/resources/encryption/server-private-jwkset
@@ -1,0 +1,32 @@
+{
+  "keys": [
+    {
+        "p": "9zfRNgsBbDzNTdPp5PXuY5w9S_xUGoo0yipqOOG2vu8dH0UPwAEnn2uKrXYaxGhbnLju8JmVu4dstGROOWs8QAAkM8UmU-qZSt1PtdtBClkc6_6qgJC4LWU9U9IxzG4UBOQUgga3m6e3PuiMiHktOvWWYmih5ZuExzqShBtDBac",
+        "kty": "RSA",
+        "q": "kM4nThLi-Syy7T7XFFkt0v7QkJrWgWJcJEaLGya_CqRDBwXyZBNbYWvJBGK2RiHvKysTzMgVXwwizZGBtQ2EKUYfmxsHNWNzlXQ3Y534vN4AXOOmUFoapyh97AA0R8GK9S6BHyQ9bdMMJ6urm8d_A9Vg_NhATvQdaxZfPw7xAac",
+        "d": "DlqCk92Lz1Z_p5TQ2tt8l-UOXXWTOZvo_q5OEHzw97aqXkkzb9g4Yeu9z7Q1p5dCmgy9YnRknw5t0isVJv-3_oK1d3FKG_Ymn2s6zwZ4A7v-n32yiuUZTuCF_11UT3aIlHGrv16JeuwRDW18fF7c91Q4NjGzFzdO280sUzPCeNeCflqeDL28PcKnfXo0Nqo0Qhk8vNR_1GKpAaus0gcfTtob1qHd065w5I7I6rCaFGIxGPqtRdsuNFsa2HoOIpIta1DXNUgtiH2lPHGKSIYvxEM3LYdNapQY4uBX15skv0qO2WQZAeQ-gpFC1pm7Y9CDejllNd4jOlx3gOJArDa-fQ",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "hwtest",
+        "qi": "2j6-WgLLzNLqVxfrFf2CIBD5fVWx9_LuLXLv_ULApuLIQobhuYGzBeoXUKh5dp2XIE4g535t0cG41eo4wdzSp3C3xcFVa1I2Ob18GlJAVXJxQjp0OyzaCkWQEuwONus800pC9FVBwHc0GHWWhw4NL4i3KIH24ZxaYkEFXWUlp4k",
+        "dp": "VIA2uZM_dEDAKCcUHpfVWSTxasSf9sZgzu16i2DTdyYCPUr83DNI2NwIdcwV0Cafkc1AlurYXFYo2OwkNMoruPCTb0KnHC3nIcjN0ypTa_cTxLKykulkmtetA7aoIOlLXHSdcehb4A-OuikAyDErPajuM0ryc6oZ04N4y0EKQqc",
+        "alg": "RS256",
+        "dq": "QRMkPsXmEqyvzEaNSau6GDRDbnjnJUYauoKpSQ5klFe1d5aIk8jPLDzQHZRu7Z2aaf_16fWRBSHjEhbt_3uPhSzqTz4aQzfqXaPYsH_xpI7wAs6bk0iq6awcys5csFKeLAk2JdSXdp99uuY_PMauof5mk7prTBAQmGt5alFApck",
+        "n": "i9Z6jaXLvsjRsHtRFYOwhDEaAvdPsgd7XFWTzNDAlhPKwiSsz-w4QGUQwuvrmDgZ7XrcKLYF1vCe8WILHYa3b8vJbxzxeOmbhFBOU__PrVf1yBIKJTRpCFPoZrl4eeLZ3hBfBr8lxMSrnIsNRqT72_fqK_0oG33Gzn2qFbHlw7moNpJto7m8Mp7pwOJzdmZEPbj90MqocKNARfs-3OJfcAms7IFNWm4YNQusbE0-8TRsJSc-o3vXUIS1IQokTl6bpAsziZP5mCa-YFKmA-sNXmzWcO2kHw4tOOBOA8Gdsos7OMpQTJufJSElpp8yICtwLdR0HjCt-jc3lMnJf_VW8Q"
+    },
+    {
+        "p": "1RzF27Wt8jokEceSWWUR9eDDHJevLokA1l81kdSYapI8U16jLPC0vVvGuDChQL4U_7CF7Ob-HYCcajv0olwHpdWXMf3h0SNe6obfdMTetHYqP0qML4vlPaeFry4J2aaIHRp0jBiWXcfrqdSwbQsMDmUNS3R7le5iLFbLiICHV-0",
+        "kty": "RSA",
+        "q": "sl8PhxYBi2PCKg9Ll5OYmbNoHOue4fDmaHbRRpYjcWdPUqkyjXIBUde_VnPmkDMegiZO3wgFEQzcsvKAJJcyEohSGjhNL7vS04FZrd-nFKxEkKj05HLYAW2foasclFcXXvREBPzoNwiUol4_46NY_PtliwUvYxCuFFGPJu3k1Bc",
+        "d": "gR3sBksVbCsR3bBbYnNXp1rXpTFgFUTU87-zj0Vz0xLys0YZfS1v2sBbSSFlUJJjzKh-WbE0S97_M3i2w9YD5h_m_R7rTpJG82w6vedj9Tm8enukgJmkEXC2N-JXQV-C7s6rbRxvNe-tcogrRSNL_pSTOrlBobdFLF28--7CyNFWpP3qlOKXMzMTKrQYSJBtE2gnXbKL6PEVj2Qvop4VNPaYFlCS7beA-xRX9dZuoEkbZtDO2mLAM5jpJBuPdNAehNtJdvUi1sNr-2gTEdDQcYqourcLUJHRwbIjnqbfVTpOxJ-79wLyhLnd6dG5wf5nnudk3UholaaE6_A4RmNlmQ",
+        "e": "AQAB",
+        "use": "enc",
+        "kid": "hwtestenc",
+        "qi": "FiN8kp3HF3zxBOqzWscu4fqXXWa3FdqSsZSfMZ52xF_bHz7q24Wwbpku4ciDasKzgTtgpD_fNOfV2jVXDOjhTMN5mFzrfQU8uFoDamIzHUfu-I0yHIJE8isJj81fhJgDKGZy8RmIwc5k9hPRdScUthPTW2p1PdllJNQrKTvdLEI",
+        "dp": "NHRfkwO16_A5npKzyAMjl5SaEbiYKukX5qwKoHlmhpy18oNRwKcCpbUoRX_awPfIbWMCo9v7YkGcvl1BipECZOQc0fY-ld6R50IJUFGAy4RmQ6vSs4VIiJNqSUMYs5TU3ez8ENugbzbdH7E1N7HHZueijRb_sFi7m1RFxrR0G8U",
+        "alg": "RSA-OAEP-256",
+        "dq": "cra4IcSBUcfig3I6x0zhA1hiSNcv41cul1hy1taQDMrINP0jydvcBWqfX1ZCndKCeGlyp_VcbM680UksKFwkk86gHsS-v0goGmZB6pS_u4fewLooZROG38REuZB2XOB141dst1h_b4VRMeszY48WF_0GHRZEl42Opvqc-ghc9hk",
+        "n": "lH0kLVTxVqKjPi2jGpV8Exy9zot9fCgQGlPZanm1gwdst88AftIJEPNBcgDBtvtKDzrkunZhOeXAiRppOFKoAHv5I_N6PtFa09eLI56iYTYCT1xVbP8E6jYqgiSgPxDQ3T3dJeshZIALXch091ZFEoPfq6xyGT3Us7idfOfrldh6A1A7z5zNpTR6GdfXO9QgRN0YKWj67K9Qjj1Jf-Cp3AM1yENz0pVr-30fTiaY0JF6rZ2if3tDLHMu28r6Hlg99jqwlUmMFhhlWGWMQUnIqPC6vrSr-IJT1tC28n0W8d16SGLCJIi8diw0n0pNVCjYtcP4qOxP1hqFGojSWQ0qSw"
+    }
+  ]
+}

--- a/src/test/resources/encryption/server-public-jwkset
+++ b/src/test/resources/encryption/server-public-jwkset
@@ -1,0 +1,20 @@
+{
+  "keys": [
+    {
+        "kty": "RSA",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "hwtest",
+        "alg": "RS256",
+        "n": "i9Z6jaXLvsjRsHtRFYOwhDEaAvdPsgd7XFWTzNDAlhPKwiSsz-w4QGUQwuvrmDgZ7XrcKLYF1vCe8WILHYa3b8vJbxzxeOmbhFBOU__PrVf1yBIKJTRpCFPoZrl4eeLZ3hBfBr8lxMSrnIsNRqT72_fqK_0oG33Gzn2qFbHlw7moNpJto7m8Mp7pwOJzdmZEPbj90MqocKNARfs-3OJfcAms7IFNWm4YNQusbE0-8TRsJSc-o3vXUIS1IQokTl6bpAsziZP5mCa-YFKmA-sNXmzWcO2kHw4tOOBOA8Gdsos7OMpQTJufJSElpp8yICtwLdR0HjCt-jc3lMnJf_VW8Q"
+    },
+    {
+        "kty": "RSA",
+        "e": "AQAB",
+        "use": "enc",
+        "kid": "hwtestenc",
+        "alg": "RSA-OAEP-256",
+        "n": "lH0kLVTxVqKjPi2jGpV8Exy9zot9fCgQGlPZanm1gwdst88AftIJEPNBcgDBtvtKDzrkunZhOeXAiRppOFKoAHv5I_N6PtFa09eLI56iYTYCT1xVbP8E6jYqgiSgPxDQ3T3dJeshZIALXch091ZFEoPfq6xyGT3Us7idfOfrldh6A1A7z5zNpTR6GdfXO9QgRN0YKWj67K9Qjj1Jf-Cp3AM1yENz0pVr-30fTiaY0JF6rZ2if3tDLHMu28r6Hlg99jqwlUmMFhhlWGWMQUnIqPC6vrSr-IJT1tC28n0W8d16SGLCJIi8diw0n0pNVCjYtcP4qOxP1hqFGojSWQ0qSw"
+    }
+  ]
+}


### PR DESCRIPTION
**Changes in this pull request:**
- Hardening error response handler to return the correct response status and message from the server when there is an exception converting
- Update decryptErrorResponse to check for content-type before attempting to decrypt (because it's possible that the response is not encrypted)


**Testing:**
GET/PUT/POST
Successful Response
Error Response
- Empty Body 
- Hyperwallet Error Response - Content-Type - application/json 
- Hyperwallet Encrypted Error Response - Content-Type - application/jose+json
- Unrecognized Error Response - Content-Type - text/html

```
Tests run: 1665, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.994 sec - in TestSuite

Results :

Tests run: 1665, Failures: 0, Errors: 0, Skipped: 0
```