### PR TITLE
Feature/dtpayetwo 759 hw parity paypal account java dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 =========
+2.4.4
+-------------------
+- Added field 'accountId' to PayPal.
+- PayPal account creation allowed using field 'accountId' which accepts Email, Phone Number, PayPal PayerID.
+- Venmo account creation allowed using field 'accountId' which accepts Email, Phone Number, Venmo Handle, Venmo External ID.
 
 2.4.3
 -----------------

--- a/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
+++ b/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
@@ -1527,8 +1527,8 @@ public class Hyperwallet {
         if (StringUtils.isEmpty(payPalAccount.getTransferMethodCurrency())) {
             throw new HyperwalletException("Transfer Method Currency is required");
         }
-        if (StringUtils.isEmpty(payPalAccount.getEmail())) {
-            throw new HyperwalletException("Email is required");
+        if (StringUtils.isEmpty(payPalAccount.getEmail()) && StringUtils.isEmpty(payPalAccount.getAccountId())) {
+            throw new HyperwalletException("Email/AccountId is required");
         }
         if (!StringUtils.isEmpty(payPalAccount.getToken())) {
             throw new HyperwalletException("PayPal Account token may not be present");

--- a/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
+++ b/src/main/java/com/hyperwallet/clientsdk/Hyperwallet.java
@@ -1528,7 +1528,7 @@ public class Hyperwallet {
             throw new HyperwalletException("Transfer Method Currency is required");
         }
         if (StringUtils.isEmpty(payPalAccount.getEmail()) && StringUtils.isEmpty(payPalAccount.getAccountId())) {
-            throw new HyperwalletException("Email/AccountId is required");
+            throw new HyperwalletException("Email or AccountId is required");
         }
         if (!StringUtils.isEmpty(payPalAccount.getToken())) {
             throw new HyperwalletException("PayPal Account token may not be present");

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayPalAccount.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayPalAccount.java
@@ -27,6 +27,7 @@ public class HyperwalletPayPalAccount extends HyperwalletBaseMonitor {
     private Boolean isDefaultTransferMethod;
     private String email;
     private String userToken;
+    private String accountId;
     private List<HyperwalletLink> links;
 
     public String getToken() {
@@ -194,6 +195,27 @@ public class HyperwalletPayPalAccount extends HyperwalletBaseMonitor {
     public HyperwalletPayPalAccount clearEmail() {
         clearField("email");
         this.email = null;
+        return this;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        addField("accountId", accountId);
+        this.accountId = accountId;
+    }
+
+    public HyperwalletPayPalAccount accountId(String accountId) {
+        addField("accountId", accountId);
+        this.accountId = accountId;
+        return this;
+    }
+
+    public HyperwalletPayPalAccount clearAccountId() {
+        clearField("accountId");
+        this.accountId = null;
         return this;
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
@@ -3323,6 +3323,93 @@ public class HyperwalletIT {
                         ".eyJzdWIiOiJ1c3ItMmQyZGNlYWMtNDlmNi00YWQwLTk0N2YtMTIwOTIzNzhhMmQyIiwiaWF0IjoxNTQ0ODI5ODA2LCJleHAiOjE1NDQ4MzA0MDYsImF1ZCI6InBndS03YTEyMzJlOC0xNDc5LTQzNzAtOWY1NC03ODc1ZjdiMTg2NmMiLCJpc3MiOiJwcmctY2NhODAyNWUtODVhMy0xMWU2LTg2MGEtNThhZDVlY2NlNjFkIiwicmVzdC11cmkiOiJodHRwczovL3FhbWFzdGVyLWh5cGVyd2FsbGV0LmF3cy5wYXlsdXRpb24ubmV0L3Jlc3QvdjMvIiwiZ3JhcGhxbC11cmkiOiJodHRwczovL3FhbWFzdGVyLWh5cGVyd2FsbGV0LmF3cy5wYXlsdXRpb24ubmV0L2dyYXBocWwifQ.pGOdbYermGhiON5IFKSnXZd6Zj hktMd3WEDOMplYyAeiqVeZGck04eVpsBaXEqYp78NJIs7J5kMX-rPgFYxHpw")));
     }
 
+    @Test
+    public void createPayPalAccountWithAccountId() throws Exception {
+        String functionality = "createPayPalAccountWithAccountId";
+        initMockServer(functionality);
+
+        HyperwalletPayPalAccount payPalAccount = new HyperwalletPayPalAccount()
+                .userToken("usr-e7b61829-a73a-45dc-930e-afa8a56b924c")
+                .transferMethodCountry("US")
+                .transferMethodCurrency("USD")
+                .type(HyperwalletPayPalAccount.Type.PAYPAL_ACCOUNT)
+                .accountId("K8QRQHMYWETL9");
+
+        HyperwalletPayPalAccount returnValue;
+        try {
+            returnValue = client.createPayPalAccount(payPalAccount);
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+        List<HyperwalletLink> hyperwalletLinks = new ArrayList<>();
+        HyperwalletLink hyperwalletLink = new HyperwalletLink();
+        hyperwalletLink.setHref(
+                "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b924c/paypal-accounts/trm-54b0db9c-5565-47f7"
+                        + "-aee6-685e713595f4");
+        Map<String, String> mapParams = new HashMap<>();
+        mapParams.put("rel", "self");
+        hyperwalletLink.setParams(mapParams);
+        hyperwalletLinks.add(hyperwalletLink);
+
+        assertThat(returnValue.getToken(), is(equalTo("trm-54b0db9c-5565-47f7-aee6-afa8a56b924c")));
+        assertThat(returnValue.getStatus(), is(equalTo(HyperwalletPayPalAccount.Status.ACTIVATED)));
+        assertThat(returnValue.getType(), is(equalTo(HyperwalletPayPalAccount.Type.PAYPAL_ACCOUNT)));
+        assertThat(returnValue.getCreatedOn(), is(equalTo(dateFormat.parse("2022-11-11T00:00:00 UTC"))));
+        assertThat(returnValue.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(returnValue.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(returnValue.getAccountId(), is(equalTo("K8QRQHMYWETL9")));
+        if (returnValue.getLinks() != null) {
+            HyperwalletLink actualHyperwalletLink = returnValue.getLinks().get(0);
+            HyperwalletLink expectedHyperwalletLink = hyperwalletLinks.get(0);
+            assertThat(actualHyperwalletLink.getHref(), is(equalTo(expectedHyperwalletLink.getHref())));
+            assertEquals(actualHyperwalletLink.getParams(), expectedHyperwalletLink.getParams());
+        }
+    }
+
+    @Test
+    public void createVenmoAccountWithEmail() throws Exception {
+        String functionality = "createVenmoAccountWithEmail";
+        initMockServer(functionality);
+
+        HyperwalletVenmoAccount venmoAccount = new HyperwalletVenmoAccount()
+                .userToken("usr-c4292f1a-866f-4310-a289-b916853939ef")
+                .transferMethodCountry("US")
+                .transferMethodCurrency("USD")
+                .type(HyperwalletVenmoAccount.Type.VENMO_ACCOUNT)
+                .accountId("user@domain.com");
+
+        HyperwalletVenmoAccount returnValue;
+        try {
+            returnValue = client.createVenmoAccount(venmoAccount);
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+        List<HyperwalletLink> hyperwalletLinks = new ArrayList<>();
+        HyperwalletLink hyperwalletLink = new HyperwalletLink();
+        hyperwalletLink.setHref(
+                "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-c4292f1a-866f-4310-a289-b916853939ef/venmo-accounts/trm-ac5727ac-8fe7-42fb"
+                        + "-b69d-977ebdd7b49c");
+        Map<String, String> mapParams = new HashMap<>();
+        mapParams.put("rel", "self");
+        hyperwalletLink.setParams(mapParams);
+        hyperwalletLinks.add(hyperwalletLink);
+        assertThat(returnValue.getToken(), is(equalTo("trm-ac5727ac-8fe7-42fb-b69d-977ebdd7b49c")));
+        assertThat(returnValue.getStatus(), is(equalTo(HyperwalletVenmoAccount.Status.ACTIVATED)));
+        assertThat(returnValue.getType(), is(equalTo(HyperwalletVenmoAccount.Type.VENMO_ACCOUNT)));
+        assertThat(returnValue.getCreatedOn(), is(equalTo(dateFormat.parse("2022-11-11T22:50:14 UTC"))));
+        assertThat(returnValue.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(returnValue.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(returnValue.getAccountId(), is(equalTo("user@domain.com")));
+        if (returnValue.getLinks() != null) {
+            HyperwalletLink actualHyperwalletLink = returnValue.getLinks().get(0);
+            HyperwalletLink expectedHyperwalletLink = hyperwalletLinks.get(0);
+            assertThat(actualHyperwalletLink.getHref(), is(equalTo(expectedHyperwalletLink.getHref())));
+            assertEquals(actualHyperwalletLink.getParams(), expectedHyperwalletLink.getParams());
+        }
+    }
+
 
     private void initMockServerWithErrorResponse(String functionality) throws IOException {
         mockServer.reset();

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
@@ -3656,8 +3656,8 @@ public class HyperwalletTest {
         } catch (HyperwalletException e) {
             assertThat(e.getErrorCode(), is(nullValue()));
             assertThat(e.getResponse(), is(nullValue()));
-            assertThat(e.getErrorMessage(), is(equalTo("Email/AccountId is required")));
-            assertThat(e.getMessage(), is(equalTo("Email/AccountId is required")));
+            assertThat(e.getErrorMessage(), is(equalTo("Email or AccountId is required")));
+            assertThat(e.getMessage(), is(equalTo("Email or AccountId is required")));
             assertThat(e.getHyperwalletErrors(), is(nullValue()));
             assertThat(e.getRelatedResources(), is(nullValue()));
         }

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletTest.java
@@ -3656,8 +3656,8 @@ public class HyperwalletTest {
         } catch (HyperwalletException e) {
             assertThat(e.getErrorCode(), is(nullValue()));
             assertThat(e.getResponse(), is(nullValue()));
-            assertThat(e.getErrorMessage(), is(equalTo("Email is required")));
-            assertThat(e.getMessage(), is(equalTo("Email is required")));
+            assertThat(e.getErrorMessage(), is(equalTo("Email/AccountId is required")));
+            assertThat(e.getMessage(), is(equalTo("Email/AccountId is required")));
             assertThat(e.getHyperwalletErrors(), is(nullValue()));
             assertThat(e.getRelatedResources(), is(nullValue()));
         }
@@ -8865,5 +8865,43 @@ public class HyperwalletTest {
             checkHyperwalletException(e, expectedException);
         }
     }
+
+    @Test
+    public void createPayPalAccountWithAccountId() throws Exception {
+        HyperwalletPayPalAccount payPalAccount = new HyperwalletPayPalAccount();
+        payPalAccount.setUserToken("test-user-token");
+        payPalAccount.setTransferMethodCountry("test-transfer-method-country");
+        payPalAccount.setTransferMethodCurrency("test-transfer-method-currency");
+        payPalAccount.setAccountId("test-accountId");
+        payPalAccount.setStatus(HyperwalletPayPalAccount.Status.ACTIVATED);
+        payPalAccount.setCreatedOn(new Date());
+
+        HyperwalletPayPalAccount payPalAccountResponse = new HyperwalletPayPalAccount();
+
+        Hyperwallet client = new Hyperwallet("test-username", "test-password");
+        HyperwalletApiClient mockApiClient = createAndInjectHyperwalletApiClientMock(client);
+
+        Mockito.when(mockApiClient.post(ArgumentMatchers.anyString(), ArgumentMatchers.anyObject(), ArgumentMatchers.any(Class.class)))
+                .thenReturn(payPalAccountResponse);
+
+        HyperwalletPayPalAccount resp = client.createPayPalAccount(payPalAccount);
+        assertThat(resp, is(equalTo(payPalAccountResponse)));
+
+        ArgumentCaptor<HyperwalletPayPalAccount> argument = ArgumentCaptor.forClass(HyperwalletPayPalAccount.class);
+        Mockito.verify(mockApiClient)
+                .post(ArgumentMatchers.eq("https://api.sandbox.hyperwallet.com/rest/v4/users/test-user-token/paypal-accounts"), argument.capture(),
+                        ArgumentMatchers.eq(payPalAccount.getClass()));
+
+        HyperwalletPayPalAccount apiPayPalAccount = argument.getValue();
+        assertThat(apiPayPalAccount, is(notNullValue()));
+        assertThat(apiPayPalAccount.getUserToken(), is(equalTo("test-user-token")));
+        assertThat(apiPayPalAccount.getTransferMethodCountry(), is(equalTo("test-transfer-method-country")));
+        assertThat(apiPayPalAccount.getTransferMethodCurrency(), is(equalTo("test-transfer-method-currency")));
+        assertThat(apiPayPalAccount.getAccountId(), is(equalTo("test-accountId")));
+        assertThat(apiPayPalAccount.getStatus(), is(nullValue()));
+        assertThat(apiPayPalAccount.getCreatedOn(), is(nullValue()));
+        assertThat(apiPayPalAccount.getType(), is(HyperwalletPayPalAccount.Type.PAYPAL_ACCOUNT));
+    }
+
 
 }

--- a/src/test/resources/integration/createPayPalAccountWithAccountId-request.txt
+++ b/src/test/resources/integration/createPayPalAccountWithAccountId-request.txt
@@ -1,0 +1,11 @@
+curl -X "POST" "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b924c/paypal-accounts" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Content-Type: application/json" \
+-H "Accept: application/json" \
+-d "{
+   "type": "PAYPAL_ACCOUNT",
+   "transferMethodCountry": "US",
+   "transferMethodCurrency": "USD",
+   "accountId": "K8QRQHMYWETL9",
+   "userToken": "usr-e7b61829-a73a-45dc-930e-afa8a56b924c"
+}"

--- a/src/test/resources/integration/createPayPalAccountWithAccountId-response.json
+++ b/src/test/resources/integration/createPayPalAccountWithAccountId-response.json
@@ -1,0 +1,17 @@
+{
+  "token": "trm-54b0db9c-5565-47f7-aee6-afa8a56b924c",
+  "type": "PAYPAL_ACCOUNT",
+  "status": "ACTIVATED",
+  "createdOn": "2022-11-11T00:00:00",
+  "transferMethodCountry": "US",
+  "transferMethodCurrency": "USD",
+  "accountId": "K8QRQHMYWETL9",
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b924c/paypal-accounts/trm-54b0db9c-5565-47f7-aee6-685e713595f4"
+    }
+  ]
+}

--- a/src/test/resources/integration/createVenmoAccountWithEmail-request.txt
+++ b/src/test/resources/integration/createVenmoAccountWithEmail-request.txt
@@ -1,0 +1,10 @@
+curl -X "POST" "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-c4292f1a-866f-4310-a289-b916853939ef/venmo-accounts" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Content-Type: application/json" \
+-H "Accept: application/json"  \
+-d "{
+  "type": "VENMO_ACCOUNT",
+  "transferMethodCountry": "US",
+  "transferMethodCurrency": "USD",
+  "accountId": "user@domain.com"
+}"

--- a/src/test/resources/integration/createVenmoAccountWithEmail-response.json
+++ b/src/test/resources/integration/createVenmoAccountWithEmail-response.json
@@ -1,0 +1,17 @@
+{
+  "token": "trm-ac5727ac-8fe7-42fb-b69d-977ebdd7b49c",
+  "type": "VENMO_ACCOUNT",
+  "status": "ACTIVATED",
+  "createdOn": "2022-11-11T22:50:14",
+  "transferMethodCountry": "US",
+  "transferMethodCurrency": "USD",
+  "accountId": "user@domain.com",
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-c4292f1a-866f-4310-a289-b916853939ef/venmo-accounts/trm-ac5727ac-8fe7-42fb-b69d-977ebdd7b49c"
+    }
+  ]
+}


### PR DESCRIPTION
JIRA Ticket: [DTPAYETWO-759](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-759)


## JIRA Tickets: 
- [Dev: DTPAYETWO-592](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-592)
- [UT/IT: DTPAYETWO-593](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-593)
-----
# Overview
**The Design Documentation can be found here: [HW Parity with Masspay (REST API)](https://engineering.paypalcorp.com/confluence/pages/viewpage.action?spaceKey=Payouts&title=HW+Parity+with+Masspay#HWParitywithMasspay-RESTAPI(JIRA:DTPAYETWO-592))**

Currently when creating External Accounts (EA) such as PayPal & Venmo through the REST API method, account numbers were specified to be the following:
 EA Type        | Account Number Type          |
| ------------ |:-----------------------:|
| PayPal       | Email                      |
| Venmo      | Phone Number      |

This has now been changed to support the following:
 EA Type        | Account Number Type          |
| ------------ |:-----------------------:|
| PayPal       | Email, Phone Number, PayPal PayerID                                      |
| Venmo      | Email, Phone Number, Venmo Handle, Venmo External ID      |

With this change, there is a new option to use the "accountId" key-value pair in the HTTP POST Request Body. When GETting an EA, the response body will show this "accountId" value as well. Users are still able to use the "email" key-value if they wish to as well. 
```
OLD:
{
    "type": "PAYPAL_ACCOUNT",
    "transferMethodCountry": "US",
    "transferMethodCurrency": "USD",
    "email": "user@domain.com"
}

------------------------------------------------

NEW:
{
    "type": "PAYPAL_ACCOUNT",
    "transferMethodCountry": "US",
    "transferMethodCurrency": "USD",
    "accountId": "user@domain.com"
}
```

Added new wallet attribute USE_EMAIL_TAG_FOR_PAYPAL_EA_REST_API. 

- If this is enabled for a merchant then they will continue using 'email' in API request & response representation will also have 'email'.
- If this is disabled for a merchant then they will be using 'accountId' in API request & response representation will also have 'accountId'.

Hence we have added a generic error 'email/accountId is required' to accomodate both based on wallet attribute USE_EMAIL_TAG_FOR_PAYPAL_EA_REST_API. Moving forward all merchants will start using accountId. 