### PR TITLE
DTPAYETWO-761- Added 'isDefaultTransferMethod' attribute for default accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+2.4.4
+-------------------
+- Added attribute 'isDefaultTransferMethod' to identify default accounts.
 
 2.4.3
 -----------------

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccount.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccount.java
@@ -86,6 +86,8 @@ public class HyperwalletBankAccount extends HyperwalletBaseMonitor {
     private String stateProvince;
     private String postalCode;
     private String country;
+    private Boolean isDefaultTransferMethod;
+
     private List<HyperwalletLink> links;
 
     public String getToken() {
@@ -1366,6 +1368,27 @@ public class HyperwalletBankAccount extends HyperwalletBaseMonitor {
     public HyperwalletBankAccount clearLinks() {
         clearField("links");
         this.links = null;
+        return this;
+    }
+
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletBankAccount isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletBankAccount clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
         return this;
     }
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
@@ -37,6 +37,8 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
     private String cvv;
     private String userToken;
     private String processingTime;
+    private Boolean isDefaultTransferMethod;
+
     private List<HyperwalletLink> links;
 
     public Type getType() {
@@ -333,5 +335,25 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
         return this;
     }
 
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletBankCard isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletBankCard clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
+        return this;
+    }
 
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCard.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCard.java
@@ -41,6 +41,8 @@ public class HyperwalletPrepaidCard extends HyperwalletBaseMonitor {
     private String userToken;
     private List<HyperwalletLink> links;
     private String replacementOf;
+    private Boolean isDefaultTransferMethod;
+
     private EReplacePrepaidCardReason replacementReason;
 
     public Type getType() {
@@ -358,5 +360,25 @@ public class HyperwalletPrepaidCard extends HyperwalletBaseMonitor {
         return this;
     }
 
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletPrepaidCard isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletPrepaidCard clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
+        return this;
+    }
 
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethod.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethod.java
@@ -86,6 +86,7 @@ public class HyperwalletTransferMethod extends HyperwalletBaseMonitor {
     private String stateProvince;
     private String postalCode;
     private String country;
+    private Boolean isDefaultTransferMethod;
     private List<HyperwalletLink> links;
 
     public String getToken() {
@@ -1411,5 +1412,24 @@ public class HyperwalletTransferMethod extends HyperwalletBaseMonitor {
         return this;
     }
 
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
 
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletTransferMethod isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletTransferMethod clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
+        return this;
+    }
 }

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
@@ -3322,7 +3322,93 @@ public class HyperwalletIT {
                         +
                         ".eyJzdWIiOiJ1c3ItMmQyZGNlYWMtNDlmNi00YWQwLTk0N2YtMTIwOTIzNzhhMmQyIiwiaWF0IjoxNTQ0ODI5ODA2LCJleHAiOjE1NDQ4MzA0MDYsImF1ZCI6InBndS03YTEyMzJlOC0xNDc5LTQzNzAtOWY1NC03ODc1ZjdiMTg2NmMiLCJpc3MiOiJwcmctY2NhODAyNWUtODVhMy0xMWU2LTg2MGEtNThhZDVlY2NlNjFkIiwicmVzdC11cmkiOiJodHRwczovL3FhbWFzdGVyLWh5cGVyd2FsbGV0LmF3cy5wYXlsdXRpb24ubmV0L3Jlc3QvdjMvIiwiZ3JhcGhxbC11cmkiOiJodHRwczovL3FhbWFzdGVyLWh5cGVyd2FsbGV0LmF3cy5wYXlsdXRpb24ubmV0L2dyYXBocWwifQ.pGOdbYermGhiON5IFKSnXZd6Zj hktMd3WEDOMplYyAeiqVeZGck04eVpsBaXEqYp78NJIs7J5kMX-rPgFYxHpw")));
     }
+    @Test
+    public void testListTransferMethodsDefaultTransfer() throws Exception {
+        String functionality = "listTransferMethodsDefaultTransfer";
+        initMockServer(functionality);
 
+        HyperwalletList<HyperwalletTransferMethod> returnValue;
+        try {
+            String userToken = "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae";
+            returnValue = client.listTransferMethods(userToken, null);
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+
+        List<HyperwalletLink> hyperwalletLinks = new ArrayList<>();
+        HyperwalletLink hyperwalletLink = new HyperwalletLink();
+        hyperwalletLink.setHref(
+                "https://localhost-hyperwallet.aws.paylution.net:8181/rest/v4/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods?limit"
+                        + "=100");
+        Map<String, String> mapParams = new HashMap<>();
+        mapParams.put("rel", "self");
+        hyperwalletLink.setParams(mapParams);
+        hyperwalletLinks.add(hyperwalletLink);
+
+        assertFalse(returnValue.hasNextPage());
+        assertFalse(returnValue.hasPreviousPage());
+
+        HyperwalletTransferMethod cardTransferMethod = returnValue.getData().get(1);
+
+        assertThat(cardTransferMethod.getToken(), is(equalTo("trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff")));
+        assertThat(cardTransferMethod.getType(), is(equalTo(HyperwalletTransferMethod.Type.PREPAID_CARD)));
+        assertThat(cardTransferMethod.getStatus(), is(equalTo(HyperwalletTransferMethod.Status.ACTIVATED)));
+        assertThat(cardTransferMethod.getVerificationStatus(), is(equalTo(VerificationStatus.NOT_REQUIRED)));
+        assertThat(cardTransferMethod.getCreatedOn(), is(equalTo(dateFormat.parse("2022-09-09T18:43:34 UTC"))));
+        assertThat(cardTransferMethod.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(cardTransferMethod.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(cardTransferMethod.getCardType(), is(equalTo(CardType.PERSONALIZED)));
+        assertThat(cardTransferMethod.getCardPackage(), is(equalTo("L1")));
+        assertThat(cardTransferMethod.getCardNumber(), is(equalTo("************4194")));
+        assertThat(cardTransferMethod.getCardBrand(), is(equalTo(Brand.VISA)));
+        assertThat(cardTransferMethod.getDateOfExpiry(), is(equalTo(dateFormat.parse("2025-09-01T00:00:00 UTC"))));
+        assertThat(cardTransferMethod.getIsDefaultTransferMethod(), is(equalTo(Boolean.TRUE)));
+        assertThat(cardTransferMethod.getUserToken(), is(equalTo("usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae")));
+
+        HyperwalletLink actualHyperwalletLink = returnValue.getLinks().get(0);
+        HyperwalletLink expectedHyperwalletLink = hyperwalletLinks.get(0);
+        assertThat(actualHyperwalletLink.getHref(), is(equalTo(expectedHyperwalletLink.getHref())));
+        assertEquals(actualHyperwalletLink.getParams(), expectedHyperwalletLink.getParams());
+    }
+
+    @Test
+    public void testGetPayPalAccountDefaultTransfer() throws Exception {
+        String functionality = "getPayPalAccountDefaultTransfer";
+        initMockServer(functionality);
+
+        HyperwalletPayPalAccount paypalAccount;
+        try {
+            paypalAccount = client.getPayPalAccount("usr-e7b61829-a73a-45dc-930e-afa8a56b923c", "trm-54b0db9c-5565-47f7-aee6-685e713595f4");
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+        List<HyperwalletLink> hyperwalletLinks = new ArrayList<>();
+        HyperwalletLink hyperwalletLink = new HyperwalletLink();
+        hyperwalletLink.setHref(
+                "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b923c/paypal-accounts/trm-54b0db9c-5565-47f7"
+                        + "-aee6-685e713595f4");
+        Map<String, String> mapParams = new HashMap<>();
+        mapParams.put("rel", "self");
+        hyperwalletLink.setParams(mapParams);
+        hyperwalletLinks.add(hyperwalletLink);
+
+        assertThat(paypalAccount.getToken(), is(equalTo("trm-54b0db9c-5565-47f7-aee6-685e713595f4")));
+        assertThat(paypalAccount.getStatus(), is(equalTo(HyperwalletPayPalAccount.Status.ACTIVATED)));
+        assertThat(paypalAccount.getType(), is(equalTo(HyperwalletPayPalAccount.Type.PAYPAL_ACCOUNT)));
+        assertThat(paypalAccount.getCreatedOn(), is(equalTo(dateFormat.parse("2022-05-01T00:00:00 UTC"))));
+        assertThat(paypalAccount.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(paypalAccount.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(paypalAccount.getEmail(), is(equalTo("user@domain.com")));
+        assertThat(paypalAccount.getIsDefaultTransferMethod(), is(equalTo(Boolean.TRUE)));
+        if (paypalAccount.getLinks() != null) {
+            HyperwalletLink actualHyperwalletLink = paypalAccount.getLinks().get(0);
+            HyperwalletLink expectedHyperwalletLink = hyperwalletLinks.get(0);
+            assertThat(actualHyperwalletLink.getHref(), is(equalTo(expectedHyperwalletLink.getHref())));
+            assertEquals(actualHyperwalletLink.getParams(), expectedHyperwalletLink.getParams());
+        }
+    }
 
     private void initMockServerWithErrorResponse(String functionality) throws IOException {
         mockServer.reset();

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccountTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccountTest.java
@@ -74,6 +74,7 @@ public class HyperwalletBankAccountTest extends BaseModelTest<HyperwalletBankAcc
                 .stateProvince("test-state-province")
                 .postalCode("test-postal-code")
                 .country("test-country")
+                .isDefaultTransferMethod(Boolean.TRUE)
                 .links(hyperwalletLinkList);
 
         return bankAccount;

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankCardTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankCardTest.java
@@ -27,7 +27,8 @@ public class HyperwalletBankCardTest extends BaseModelTest<HyperwalletBankCard> 
                 .cvv("cvv")
                 .processingTime("processing-time")
                 .links(hyperwalletLinkList)
-                .userToken("test-user-token");
+                .userToken("test-user-token")
+                .isDefaultTransferMethod(Boolean.TRUE);
         return bankCard;
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCardTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCardTest.java
@@ -31,6 +31,7 @@ public class HyperwalletPrepaidCardTest extends BaseModelTest<HyperwalletPrepaid
                 .userToken("test-user-token")
                 .replacementOf("replacementOf")
                 .replacementReason(EReplacePrepaidCardReason.DAMAGED)
+                .isDefaultTransferMethod(Boolean.TRUE)
                 .links(hyperwalletLinkList);
         return prepaidCard;
     }

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodTest.java
@@ -90,6 +90,7 @@ public class HyperwalletTransferMethodTest extends BaseModelTest<HyperwalletTran
                 .postalCode("test-postal-code")
                 .country("test-country")
                 .verificationStatus(VerificationStatus.NOT_REQUIRED)
+                .isDefaultTransferMethod(Boolean.TRUE)
                 .links(hyperwalletLinkList);
 
         return transferMethod;

--- a/src/test/resources/integration/getPayPalAccountDefaultTransfer-request.txt
+++ b/src/test/resources/integration/getPayPalAccountDefaultTransfer-request.txt
@@ -1,0 +1,3 @@
+curl -X "GET" "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b923c/paypal-accounts/trm-54b0db9c-5565-47f7-aee6-685e713595f4" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Accept: application/json" \

--- a/src/test/resources/integration/getPayPalAccountDefaultTransfer-response.json
+++ b/src/test/resources/integration/getPayPalAccountDefaultTransfer-response.json
@@ -1,0 +1,18 @@
+{
+  "token": "trm-54b0db9c-5565-47f7-aee6-685e713595f4",
+  "type": "PAYPAL_ACCOUNT",
+  "status": "ACTIVATED",
+  "createdOn": "2022-05-01T00:00:00",
+  "transferMethodCountry": "US",
+  "transferMethodCurrency": "USD",
+  "email": "user@domain.com",
+  "isDefaultTransferMethod": true,
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-e7b61829-a73a-45dc-930e-afa8a56b923c/paypal-accounts/trm-54b0db9c-5565-47f7-aee6-685e713595f4"
+    }
+  ]
+}

--- a/src/test/resources/integration/listTransferMethodsDefaultTransfer-request.txt
+++ b/src/test/resources/integration/listTransferMethodsDefaultTransfer-request.txt
@@ -1,0 +1,3 @@
+curl -X "GET" "https://api.sandbox.hyperwallet.com/rest/v4/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Accept: application/json"

--- a/src/test/resources/integration/listTransferMethodsDefaultTransfer-response.json
+++ b/src/test/resources/integration/listTransferMethodsDefaultTransfer-response.json
@@ -1,0 +1,74 @@
+{
+  "hasNextPage": false,
+  "hasPreviousPage": false,
+  "limit": 100,
+  "data": [
+    {
+      "token": "trm-a43b1064-da94-457f-ae56-e4f85bd36aec",
+      "type": "BANK_ACCOUNT",
+      "status": "ACTIVATED",
+      "verificationStatus": "NOT_REQUIRED",
+      "createdOn": "2022-09-09T18:43:10",
+      "transferMethodCountry": "US",
+      "transferMethodCurrency": "USD",
+      "branchId": "021000021",
+      "bankAccountId": "1599657189",
+      "bankAccountPurpose": "SAVINGS",
+      "userToken": "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae",
+      "profileType": "INDIVIDUAL",
+      "firstName": "FirstName",
+      "lastName": "LastName",
+      "dateOfBirth": "2000-09-09T18:43:10",
+      "gender": "MALE",
+      "phoneNumber": "605-555-1323",
+      "mobileNumber": "605-555-1323",
+      "governmentId": "444444444",
+      "addressLine1": "1234 IndividualAddress St",
+      "addressLine2": "1234 AddressLineTwo St",
+      "city": "TestCity",
+      "stateProvince": "CA",
+      "country": "US",
+      "postalCode": "12345",
+      "links": [
+        {
+          "params": {
+            "rel": "self"
+          },
+          "href": "https://localhost-hyperwallet.aws.paylution.net:8181/rest/v4/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods/trm-a43b1064-da94-457f-ae56-e4f85bd36aec"
+        }
+      ]
+    },
+    {
+      "token": "trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff",
+      "type": "PREPAID_CARD",
+      "status": "ACTIVATED",
+      "verificationStatus": "NOT_REQUIRED",
+      "createdOn": "2022-09-09T18:43:34",
+      "transferMethodCountry": "US",
+      "transferMethodCurrency": "USD",
+      "cardType": "PERSONALIZED",
+      "cardPackage": "L1",
+      "cardNumber": "************4194",
+      "cardBrand": "VISA",
+      "dateOfExpiry": "2025-09",
+      "userToken": "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae",
+      "isDefaultTransferMethod": true,
+      "links": [
+        {
+          "params": {
+            "rel": "self"
+          },
+          "href": "https://localhost-hyperwallet.aws.paylution.net:8181/rest/v4/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods/trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://localhost-hyperwallet.aws.paylution.net:8181/rest/v4/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods?limit=100"
+    }
+  ]
+}


### PR DESCRIPTION
Design: https://engineering.paypalcorp.com/confluence/display/Payouts/Default+Transfer+Method+in+EA+responses

The change is to refine all of the external accounts API **_responses_** (GET, GET ALL) to include a "**_isDefaultTransferMethod_**" attribute holding a boolean value and is displayed only when the attribute is true which helps in determining the default account to which payment is made.