### PR TITLE
DTPAYETWO-761- Added 'isDefaultTransferMethod' attribute for default accounts(V3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+1.9.4
+-------------------
+- Added attribute 'isDefaultTransferMethod' to identify default accounts.
+
 1.9.3
 -----------------
 - Added connection and read timeout support

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccount.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccount.java
@@ -86,6 +86,7 @@ public class HyperwalletBankAccount extends HyperwalletBaseMonitor {
     private String stateProvince;
     private String postalCode;
     private String country;
+    private Boolean isDefaultTransferMethod;
 
     public String getToken() {
         return token;
@@ -1365,6 +1366,27 @@ public class HyperwalletBankAccount extends HyperwalletBaseMonitor {
     public HyperwalletBankAccount clearCountry() {
         clearField("country");
         country = null;
+        return this;
+    }
+
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletBankAccount isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletBankAccount clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
         return this;
     }
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
@@ -18,7 +18,6 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
     public enum CardType {DEBIT}
     public static enum Type {BANK_CARD}
     public static enum Status {ACTIVATED, VERIFIED, INVALID, DE_ACTIVATED}
-
     private Type type;
     private Status status;
     private Status transition;

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletBankCard.java
@@ -18,7 +18,7 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
     public enum CardType {DEBIT}
     public static enum Type {BANK_CARD}
     public static enum Status {ACTIVATED, VERIFIED, INVALID, DE_ACTIVATED}
-    
+
     private Type type;
     private Status status;
     private Status transition;
@@ -35,6 +35,7 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
 
     private String userToken;
     private String processingTime;
+    private Boolean isDefaultTransferMethod;
 
     public Type getType() {
         return type;
@@ -328,6 +329,27 @@ public class HyperwalletBankCard extends HyperwalletBaseMonitor {
     public HyperwalletBankCard clearProcessingTime() {
         clearField("processingTime");
         this.processingTime = null;
+        return this;
+    }
+
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletBankCard isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletBankCard clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
         return this;
     }
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCard.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCard.java
@@ -35,6 +35,8 @@ public class HyperwalletPrepaidCard extends HyperwalletBaseMonitor {
     private Date dateOfExpiry;
 
     private String userToken;
+    private Boolean isDefaultTransferMethod;
+
 
     public Type getType() {
         return type;
@@ -307,6 +309,27 @@ public class HyperwalletPrepaidCard extends HyperwalletBaseMonitor {
     public HyperwalletPrepaidCard clearUserToken() {
         clearField("userToken");
         this.userToken = null;
+        return this;
+    }
+
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletPrepaidCard isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletPrepaidCard clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
         return this;
     }
 }

--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethod.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethod.java
@@ -81,6 +81,7 @@ public class HyperwalletTransferMethod extends HyperwalletBaseMonitor {
     private String stateProvince;
     private String postalCode;
     private String country;
+    private Boolean isDefaultTransferMethod;
 
     public String getToken() {
         return token;
@@ -1360,6 +1361,27 @@ public class HyperwalletTransferMethod extends HyperwalletBaseMonitor {
     public HyperwalletTransferMethod clearCardBrand() {
         clearField("cardBrand");
         this.cardBrand = null;
+        return this;
+    }
+
+    public Boolean getIsDefaultTransferMethod() {
+        return isDefaultTransferMethod;
+    }
+
+    public void setIsDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+    }
+
+    public HyperwalletTransferMethod isDefaultTransferMethod(Boolean isDefaultTransferMethod) {
+        addField("isDefaultTransferMethod", isDefaultTransferMethod);
+        this.isDefaultTransferMethod = isDefaultTransferMethod;
+        return this;
+    }
+
+    public HyperwalletTransferMethod clearIsDefaultTransferMethod() {
+        clearField("isDefaultTransferMethod");
+        this.isDefaultTransferMethod = null;
         return this;
     }
 }

--- a/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
+++ b/src/test/java/com/hyperwallet/clientsdk/HyperwalletIT.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.JsonBody.json;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
 public class HyperwalletIT {
@@ -1857,5 +1858,61 @@ public class HyperwalletIT {
         assertThat(returnValue.getToStatus(), is(equalTo(DE_ACTIVATED)));
         assertThat(returnValue.getNotes(), is(equalTo("Closing this account.")));
 
+    }
+
+    @Test
+    public void testListTransferMethodsDefaultTransfer() throws Exception {
+        String functionality = "listTransferMethodsDefaultTransfer";
+        initMockServer(functionality);
+
+        HyperwalletList<HyperwalletTransferMethod> returnValue;
+        try {
+            String userToken = "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae";
+            returnValue = client.listTransferMethods(userToken, null);
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+
+        assertThat(returnValue.getCount(), is(equalTo(2)));
+
+        HyperwalletTransferMethod cardTransferMethod = returnValue.getData().get(1);
+
+        assertThat(cardTransferMethod.getToken(), is(equalTo("trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff")));
+        assertThat(cardTransferMethod.getType(), is(equalTo(HyperwalletTransferMethod.Type.PREPAID_CARD)));
+        assertThat(cardTransferMethod.getStatus(), is(equalTo(HyperwalletTransferMethod.Status.ACTIVATED)));
+        assertThat(cardTransferMethod.getCreatedOn(), is(equalTo(dateFormat.parse("2022-09-09T18:43:34 UTC"))));
+        assertThat(cardTransferMethod.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(cardTransferMethod.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(cardTransferMethod.getCardType(), is(equalTo(CardType.PERSONALIZED)));
+        assertThat(cardTransferMethod.getCardPackage(), is(equalTo("L1")));
+        assertThat(cardTransferMethod.getCardNumber(), is(equalTo("************4194")));
+        assertThat(cardTransferMethod.getCardBrand(), is(equalTo(Brand.VISA)));
+        assertThat(cardTransferMethod.getDateOfExpiry(), is(equalTo(dateFormat.parse("2025-09-01T00:00:00 UTC"))));
+        assertThat(cardTransferMethod.getIsDefaultTransferMethod(), is(equalTo(Boolean.TRUE)));
+        assertThat(cardTransferMethod.getUserToken(), is(equalTo("usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae")));
+    }
+
+    @Test
+    public void testGetPayPalAccountDefaultTransfer() throws Exception {
+        String functionality = "getPayPalAccountDefaultTransfer";
+        initMockServer(functionality);
+
+        HyperwalletPayPalAccount paypalAccount;
+        try {
+            paypalAccount = client.getPayPalAccount("usr-e7b61829-a73a-45dc-930e-afa8a56b923c", "trm-54b0db9c-5565-47f7-aee6-685e713595f4");
+        } catch (Exception e) {
+            mockServer.verify(parseRequest(functionality));
+            throw e;
+        }
+
+        assertThat(paypalAccount.getToken(), is(equalTo("trm-54b0db9c-5565-47f7-aee6-685e713595f4")));
+        assertThat(paypalAccount.getStatus(), is(equalTo(HyperwalletPayPalAccount.Status.ACTIVATED)));
+        assertThat(paypalAccount.getType(), is(equalTo(HyperwalletPayPalAccount.Type.PAYPAL_ACCOUNT)));
+        assertThat(paypalAccount.getCreatedOn(), is(equalTo(dateFormat.parse("2022-05-01T00:00:00 UTC"))));
+        assertThat(paypalAccount.getTransferMethodCountry(), is(equalTo("US")));
+        assertThat(paypalAccount.getTransferMethodCurrency(), is(equalTo("USD")));
+        assertThat(paypalAccount.getEmail(), is(equalTo("user@domain.com")));
+        assertThat(paypalAccount.getIsDefaultTransferMethod(), is(equalTo(Boolean.TRUE)));
     }
 }

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccountTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankAccountTest.java
@@ -79,7 +79,8 @@ public class HyperwalletBankAccountTest extends BaseModelTest<HyperwalletBankAcc
                 .city("test-city")
                 .stateProvince("test-state-province")
                 .postalCode("test-postal-code")
-                .country("test-country");
+                .country("test-country")
+                .isDefaultTransferMethod(Boolean.TRUE);
 
         return bankAccount;
     }

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankCardTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletBankCardTest.java
@@ -19,7 +19,8 @@ public class HyperwalletBankCardTest extends BaseModelTest<HyperwalletBankCard> 
                 .processingTime("30 mins")
                 .dateOfExpiry(new Date())
                 .cvv("cvv")
-                .userToken("test-user-token");
+                .userToken("test-user-token")
+                .isDefaultTransferMethod(Boolean.TRUE);
         return bankCard;
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCardTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPrepaidCardTest.java
@@ -20,6 +20,7 @@ public class HyperwalletPrepaidCardTest extends BaseModelTest<HyperwalletPrepaid
                 .cardPackage("test-card-package")
                 .cardNumber("test-card-number")
                 .cardBrand(HyperwalletPrepaidCard.Brand.VISA)
+                .isDefaultTransferMethod(Boolean.TRUE)
                 .dateOfExpiry(new Date())
                 .userToken("test-user-token");
         return prepaidCard;

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletTransferMethodTest.java
@@ -81,7 +81,8 @@ public class HyperwalletTransferMethodTest extends BaseModelTest<HyperwalletTran
                 .city("test-city")
                 .stateProvince("test-state-province")
                 .postalCode("test-postal-code")
-                .country("test-country");
+                .country("test-country")
+                .isDefaultTransferMethod(Boolean.TRUE);
 
         return transferMethod;
     }

--- a/src/test/resources/integration/getPayPalAccountDefaultTransfer-request.txt
+++ b/src/test/resources/integration/getPayPalAccountDefaultTransfer-request.txt
@@ -1,0 +1,3 @@
+curl -X "GET" "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-e7b61829-a73a-45dc-930e-afa8a56b923c/paypal-accounts/trm-54b0db9c-5565-47f7-aee6-685e713595f4" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Accept: application/json" \

--- a/src/test/resources/integration/getPayPalAccountDefaultTransfer-response.json
+++ b/src/test/resources/integration/getPayPalAccountDefaultTransfer-response.json
@@ -1,0 +1,18 @@
+{
+  "token": "trm-54b0db9c-5565-47f7-aee6-685e713595f4",
+  "type": "PAYPAL_ACCOUNT",
+  "status": "ACTIVATED",
+  "createdOn": "2022-05-01T00:00:00",
+  "transferMethodCountry": "US",
+  "transferMethodCurrency": "USD",
+  "email": "user@domain.com",
+  "isDefaultTransferMethod": true,
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-e7b61829-a73a-45dc-930e-afa8a56b923c/paypal-accounts/trm-54b0db9c-5565-47f7-aee6-685e713595f4"
+    }
+  ]
+}

--- a/src/test/resources/integration/listTransferMethodsDefaultTransfer-request.txt
+++ b/src/test/resources/integration/listTransferMethodsDefaultTransfer-request.txt
@@ -1,0 +1,3 @@
+curl -X "GET" "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods" \
+-u testuser@12345678:myAccPassw0rd \
+-H "Accept: application/json"

--- a/src/test/resources/integration/listTransferMethodsDefaultTransfer-response.json
+++ b/src/test/resources/integration/listTransferMethodsDefaultTransfer-response.json
@@ -1,0 +1,74 @@
+{
+  "count": 2,
+  "offset": 0,
+  "limit": 10,
+  "data": [
+    {
+      "token": "trm-a43b1064-da94-457f-ae56-e4f85bd36aec",
+      "type": "BANK_ACCOUNT",
+      "status": "ACTIVATED",
+      "verificationStatus": "NOT_REQUIRED",
+      "createdOn": "2022-09-09T18:43:10",
+      "transferMethodCountry": "US",
+      "transferMethodCurrency": "USD",
+      "branchId": "021000021",
+      "bankAccountId": "1599657189",
+      "bankAccountPurpose": "SAVINGS",
+      "userToken": "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae",
+      "profileType": "INDIVIDUAL",
+      "firstName": "FirstName",
+      "lastName": "LastName",
+      "dateOfBirth": "2000-09-09T18:43:10",
+      "gender": "MALE",
+      "phoneNumber": "605-555-1323",
+      "mobileNumber": "605-555-1323",
+      "governmentId": "444444444",
+      "addressLine1": "1234 IndividualAddress St",
+      "addressLine2": "1234 AddressLineTwo St",
+      "city": "TestCity",
+      "stateProvince": "CA",
+      "country": "US",
+      "postalCode": "12345",
+      "links": [
+        {
+          "params": {
+            "rel": "self"
+          },
+          "href": "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods/trm-a43b1064-da94-457f-ae56-e4f85bd36aec"
+        }
+      ]
+    },
+    {
+      "token": "trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff",
+      "type": "PREPAID_CARD",
+      "status": "ACTIVATED",
+      "verificationStatus": "NOT_REQUIRED",
+      "createdOn": "2022-09-09T18:43:34",
+      "transferMethodCountry": "US",
+      "transferMethodCurrency": "USD",
+      "cardType": "PERSONALIZED",
+      "cardPackage": "L1",
+      "cardNumber": "************4194",
+      "cardBrand": "VISA",
+      "dateOfExpiry": "2025-09-01T00:00:00",
+      "userToken": "usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae",
+      "isDefaultTransferMethod": true,
+      "links": [
+        {
+          "params": {
+            "rel": "self"
+          },
+          "href": "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods/trm-c8e4c164-7d5b-4b5b-8b6a-9c4d68c2a9ff"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "params": {
+        "rel": "self"
+      },
+      "href": "https://api.sandbox.hyperwallet.com/rest/v3/users/usr-321ad2c1-df3f-4a7a-bce4-3e88416b54ae/transfer-methods?limit=100"
+    }
+  ]
+}


### PR DESCRIPTION
Design: https://engineering.paypalcorp.com/confluence/display/Payouts/Default+Transfer+Method+in+EA+responses

The change is to refine all of the external accounts API responses (GET, GET ALL) to include a "isDefaultTransferMethod" attribute holding a boolean value and is displayed only when the attribute is true which helps in determining the default account to which payment is made.