### PR TITLE
DTSERWONE-941 - Fix TestNG to fix vulnerable to Path Traversal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 11 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8, 9, 10, 11, 12, 13, 14, 15, 16 ,17, 18 ]
+        java-version: [ 11, 12, 13, 14, 15, 16 ,17, 18 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          java-version: [ 8 ]
+          java-version: [ 11 ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 11 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+2.4.5
+-------------------
+- Fix for TestNG is vulnerable to Path Traversal
+
 2.4.4
 -------------------
 - Added attribute 'isDefaultTransferMethod' to identify default accounts.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/hyperwallet/java-sdk/badge.svg?branch=master)](https://coveralls.io/github/hyperwallet/java-sdk?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/com.hyperwallet/sdk.svg)]()
 
-Hyperwallet REST SDK v2.4.3
+Hyperwallet REST SDK v2.4.5
 ===========================
 
 A library to manage users, transfer methods and payments through the Hyperwallet v4 API.
@@ -23,13 +23,13 @@ Installation
 <dependency>
     <groupId>com.hyperwallet</groupId>
     <artifactId>sdk</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
 </dependency>
 ```
 
 **Gradle**
 ```
-compile 'com.hyperwallet:sdk:2.4.3'
+compile 'com.hyperwallet:sdk:2.4.5'
 ```
 
 Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng.version>7.3.0</testng.version>
+        <testng.version>7.7.1</testng.version>
         <mockito.version>3.5.7</mockito.version>
         <protea.http.version>[0.2,)</protea.http.version>
         <jackson.jaxrs.json.provider.version>2.11.2</jackson.jaxrs.json.provider.version>


### PR DESCRIPTION
Ticket number: DTSERWONE-941 

The Github dependency bot report high severity alert  for Java-SDK   
Vulnerability report: https://github.com/hyperwallet/java-sdk/security/dependabot/1

## Changes:
- Update TestNG to latest version