### PR TITLE
Fix: Issue with expiration date computation

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
@@ -45,7 +45,7 @@ import java.util.List;
 public class HyperwalletEncryption {
 
     private static final String EXPIRATION = "exp";
-    private static final Integer MILLISECONDS_IN_ONE_MINUTE = 60000;
+    private static final Long MILLISECONDS_IN_ONE_MINUTE = 60000;
     private static final Long MILLISECONDS_IN_SECOND = 1000L;
     private static final Integer EXPIRATION_MINUTES = 5;
     private static final JWEAlgorithm ENCRYPTION_ALGORITHM = JWEAlgorithm.RSA_OAEP_256;


### PR DESCRIPTION
The value of the expiration date is not computed properly due to an integer overflow. Fixing this issue by changing the conversion variable (MILLISECONDS_IN_ONE_MINUTE) to a Long.

The following section overflows at jwsExpirationMinutes = 35_791.

`MILLISECONDS_IN_ONE_MINUTE * jwsExpirationMinutes` in `HyperwalletEncryption` line 209.
