### PR TITLE
misc(payment): Add reasonCode to HyperwalletPayment

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
+++ b/src/main/java/com/hyperwallet/clientsdk/model/HyperwalletPayment.java
@@ -16,7 +16,7 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
 
     private String token;
     private String status;
-
+    private String reasonCode;
     private Date createdOn;
     private Double amount;
     private String currency;
@@ -70,6 +70,27 @@ public class HyperwalletPayment extends HyperwalletBaseMonitor {
     public HyperwalletPayment clearStatus() {
         clearField("status");
         status = null;
+        return this;
+    }
+
+     public String getReasonCode() {
+        return this.reasonCode;
+    }
+
+    public void setReasonCode(String reasonCode) {
+        addField("reasonCode", reasonCode);
+        this.reasonCode = reasonCode;
+    }
+
+    public HyperwalletPayment reasonCode(String reasonCode) {
+        addField("reasonCode", reasonCode);
+        this.reasonCode = reasonCode;
+        return this;
+    }
+
+    public HyperwalletPayment clearReasonCode() {
+        clearField("reasonCode");
+        reasonCode = null;
         return this;
     }
 

--- a/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
+++ b/src/test/java/com/hyperwallet/clientsdk/model/HyperwalletPaymentTest.java
@@ -17,6 +17,7 @@ public class HyperwalletPaymentTest extends BaseModelTest<HyperwalletPayment> {
         payment
                 .status("COMPLETED")
                 .token("test-token")
+                .reasonCode("PAYEE_ACCOUNT_LIMITATION")
                 .createdOn(new Date())
                 .amount(15.99)
                 .currency("test-currency")


### PR DESCRIPTION
Hello 👋 

We (BlaBlaCar) recently activated the reasonCode field and we are facing an issue when parsing notifications with the HyperwalletPayment object (+ couldn't get the reasonCode) : 

```<#2f49d778> c.f.j.d.e.UnrecognizedPropertyException: Unrecognized field "reasonCode" (class com.hyperwallet.clientsdk.model.HyperwalletPayment), not marked as ignorable (14 known properties: "notes", "releaseOn", "createdOn", "destinationToken", "currency", "status", "expiresOn", "programToken", "clientPaymentId", "amount", "token", "memo", "purpose", "links"])```

There could probably be a workaround to avoid this error by skipping unknown fields on our Mapper, but we extended this POJO in our codebase as a workaround to add the reasonCode field which is quite useful for us.

Feel free to push on this branch or close this PR if not relevant

Thanks 🙏 