### PR TITLE
feat(encryption): allow custom loading of JWK sets

### DIFF
--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
@@ -106,8 +106,8 @@ public class HyperwalletEncryption {
 
     public String encrypt(String body) throws JOSEException, IOException, ParseException {
 
-        JWK clientPrivateKey = getKeyByAlgorithm(loadKeySet(clientPrivateKeySetLocation), signAlgorithm);
-        JWK hyperwalletPublicKey = getKeyByAlgorithm(loadKeySet(hyperwalletKeySetLocation), encryptionAlgorithm);
+        JWK clientPrivateKey = getKeyByAlgorithm(loadClientPrivateKeySet(), signAlgorithm);
+        JWK hyperwalletPublicKey = getKeyByAlgorithm(loadHyperwalletKeySet(), encryptionAlgorithm);
         JWSSigner jwsSigner = getJWSSigner(clientPrivateKey);
         JWEEncrypter jweEncrypter = getJWEEncrypter(hyperwalletPublicKey);
 
@@ -132,8 +132,8 @@ public class HyperwalletEncryption {
 
     public String decrypt(String body) throws ParseException, IOException, JOSEException {
 
-        JWK privateKeyToDecrypt = getKeyByAlgorithm(loadKeySet(clientPrivateKeySetLocation), encryptionAlgorithm);
-        JWK publicKeyToSign = getKeyByAlgorithm(loadKeySet(hyperwalletKeySetLocation), signAlgorithm);
+        JWK privateKeyToDecrypt = getKeyByAlgorithm(loadClientPrivateKeySet(), encryptionAlgorithm);
+        JWK publicKeyToSign = getKeyByAlgorithm(loadHyperwalletKeySet(), signAlgorithm);
         JWEDecrypter jweDecrypter = getJWEDecrypter(privateKeyToDecrypt);
         JWSVerifier jwsVerifier = getJWSVerifier(publicKeyToSign);
 
@@ -146,6 +146,14 @@ public class HyperwalletEncryption {
             throw new HyperwalletException("JWS signature is incorrect");
         }
         return jwsObject.getPayload().toString();
+    }
+
+    protected JWKSet loadClientPrivateKeySet() throws IOException, ParseException {
+        return loadKeySet(clientPrivateKeySetLocation);
+    }
+
+    protected JWKSet loadHyperwalletKeySet() throws IOException, ParseException {
+        return loadKeySet(hyperwalletKeySetLocation);
     }
 
     public void verifySignatureExpirationDate(Object signatureExpirationDate) {

--- a/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
+++ b/src/main/java/com/hyperwallet/clientsdk/util/HyperwalletEncryption.java
@@ -148,10 +148,16 @@ public class HyperwalletEncryption {
         return jwsObject.getPayload().toString();
     }
 
+    /**
+     * Allows clients to implement a custom loading of their private JWK set.
+     */
     protected JWKSet loadClientPrivateKeySet() throws IOException, ParseException {
         return loadKeySet(clientPrivateKeySetLocation);
     }
 
+    /**
+     * Allows clients to implement a custom loading of Hyperwallet public JWK set.
+     */
     protected JWKSet loadHyperwalletKeySet() throws IOException, ParseException {
         return loadKeySet(hyperwalletKeySetLocation);
     }


### PR DESCRIPTION
This would allow us to cache the JWK sets to reduce the IOs and improve performances, for instance with something along those lines:

```java
public class CachedHyperwalletEncryption extends HyperwalletEncryption {

    private final Supplier<JWKSet> clientPrivateKeySetSupplier;
    private final Supplier<JWKSet> hyperwalletKeySetSupplier;

    public CachedHyperwalletEncryption(JWEAlgorithm encryptionAlgorithm, JWSAlgorithm signAlgorithm, EncryptionMethod encryptionMethod, String clientPrivateKeySetLocation, String hyperwalletKeySetLocation, Integer jwsExpirationMinutes) {
        super(encryptionAlgorithm, signAlgorithm, encryptionMethod, clientPrivateKeySetLocation, hyperwalletKeySetLocation, jwsExpirationMinutes);
        this.clientPrivateKeySetSupplier = Suppliers.memoize(() -> super.loadClientPrivateKeySet(), CACHE_DURATION);
        this.hyperwalletKeySetSupplier = Suppliers.memoize(() -> super.loadHyperwalletKeySet(), CACHE_DURATION);
    }

    @Override
    protected JWKSet loadClientPrivateKeySet() throws IOException, ParseException {
        return clientPrivateKeySetSupplier.get();
    }

    @Override
    protected JWKSet loadHyperwalletKeySet() throws IOException, ParseException {
        return hyperwalletKeySetSupplier.get();
    }

}
```

Let me know if you think of a better approach while ensuring backward compatibility, thanks 🙌 